### PR TITLE
Testing xrange params

### DIFF
--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -54,11 +54,12 @@ class CloudPickleTest(unittest.TestCase):
         self.assertEqual(20, length)
 
         # Arbitrary steps
+        import math
         xr = xrange(3,48,2)
         start, step, length = cloudpickle.xrange_params(xr)
         self.assertEqual(3, start)
         self.assertEqual(2, step)
-        self.assertEqual(48/2-1, length)
+        self.assertEqual(math.ceil((48-3)/2.0), length)
 
         # Empty xrange
         xr = xrange(50,1,5)


### PR DESCRIPTION
This only applies to pickling Python < 2.7. We'll probably change this up for our current support of Python 2.7.x (and 3.x in the future), since 2.7+ support xrange pickling in stdlib. For now though, 

![image](https://cloud.githubusercontent.com/assets/836375/7125940/4a996252-e203-11e4-9991-3dc96a25b369.png)