### PR TITLE
Bits of boilerplate for packaging and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ python:
 install: 
   - pip install -e .
 script:
-  - python2 -m tests.cloudpickle_test
+  - python setup.py test

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,12 @@
+include AUTHORS.rst
+include CONTRIBUTING.rst
+include HISTORY.rst
+include LICENSE
+include README.rst
+include README.md
+
+recursive-include tests *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]
+
+recursive-include docs *.rst conf.py Makefile make.bat

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,16 @@
-from setuptools import setup
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
-# We disable requirements.txt parsing for now since users are having problems
-# with their cwd being elsewhere than their requirements.txt file.
-#from pip.req import parse_requirements
-# parse_requirements() returns generator of pip.req.InstallRequirement objects
-#install_reqs = [str(ir.req) for ir in parse_requirements('requirements.txt')]
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
-install_reqs = []
+requirements = [
+]
+
+test_requirements = [
+]
 
 dist = setup(
     name='cloudpickle',
@@ -15,11 +19,10 @@ dist = setup(
     author='Cloudpipe',
     author_email='cloudpipe@googlegroups.com',
     url='https://github.com/cloudpipe/cloudpickle',
-    install_requires=install_reqs,
+    install_requires=requirements,
     license='LICENSE.txt',
     packages=['cloudpickle'],
     long_description=open('README.md').read(),
-    platforms=['CPython 2.6', 'CPython 2.7'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
@@ -33,4 +36,6 @@ dist = setup(
         'Topic :: Scientific/Engineering',
         'Topic :: System :: Distributed Computing',
         ],
+    test_suite='tests',
+    tests_require=test_requirements
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py26, py27, pypy
+
+[testenv]
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}/cloudpickle
+commands = python setup.py test


### PR DESCRIPTION
* Bring in a MANIFEST.in so that the README, LICENSE, more gets packaged (would have broken dists)
* Simple setup.cfg for building wheels
* Simple tox setup
* Rely on setuptools if available
* `python setup.py test`