### PR TITLE
Pin testing dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ requirements = [
 ]
 
 test_requirements = [
-    'pytest',
-    'pytest-cov',
-    'mock'
+    'pytest==2.7.0',
+    'pytest-cov==1.8.1',
+    'mock==1.0.1'
 ]
 
 dist = setup(


### PR DESCRIPTION
Noticed in the Travis build logs that `pip` complained about the non PEP 440 versioning of `pytest-cov`:

```
...
/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'cov (core-1.14.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.
  PEP440Warning,
/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'cov (core-1.15.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.
  PEP440Warning,
/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'cov (core-1.2)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.
...
```

I've pinned the dependencies in tests so that the right version gets brought in.