### PR TITLE
adds tests for pickling of ufuncs and removes custom ufunc code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,19 @@ python:
   - "3.3"
   - "3.4"
   - "pypy"
-install: 
-  - pip install -e .
+matrix:
+  include:
+    # 0.14.0 is the last version with the old categorical system
+    - python: 3.3
+      env: PANDAS_VERSION_STR="=0.14.0"
+    - python: 2.7
+      env: PANDAS_VERSION_STR="=0.14.0"
+# This disables sudo, but makes builds start much faster
+# See http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
+sudo: false
+before_install: bash ./ci/before_install.sh
+install:
+  - pip install .
   - pip install -r dev-requirements.txt
 script:
   - PYTHONPATH='.:tests' py.test

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# if python version is not PyPY, then install miniconda
+if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]
+then
+    # Escape standard Travis virtualenv
+    deactivate
+    # See: http://conda.pydata.org/docs/travis.html
+    wget http://repo.continuum.io/miniconda/Miniconda3-3.6.0-Linux-x86_64.sh -O miniconda.sh
+    bash miniconda.sh -b -p $HOME/miniconda
+    export PATH="$HOME/miniconda/bin:$PATH"
+    hash -r
+    conda config --set always_yes yes --set changeps1 no
+    conda update -q conda
+    conda info -a
+    conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION numpy scipy pip pandas
+    source activate testenv
+fi

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -576,27 +576,9 @@ class CloudPickler(Pickler):
         dispatch[file] = save_file
 
     """Special functions for Add-on libraries"""
-
-    def inject_numpy(self):
-        numpy = sys.modules.get('numpy')
-        if not numpy or not hasattr(numpy, 'ufunc'):
-            return
-        self.dispatch[numpy.ufunc] = self.__class__.save_ufunc
-
-    def save_ufunc(self, obj):
-        """Hack function for saving numpy ufunc objects"""
-        name = obj.__name__
-        numpy_tst_mods = ['numpy', 'scipy.special']
-        for tst_mod_name in numpy_tst_mods:
-            tst_mod = sys.modules.get(tst_mod_name, None)
-            if tst_mod and name in tst_mod.__dict__:
-                return self.save_reduce(_getobject, (tst_mod_name, name))
-        raise pickle.PicklingError('cannot save %s. Cannot resolve what module it is defined in'
-                                   % str(obj))
-
     def inject_addons(self):
         """Plug in system. Register additional pickling functions if modules already loaded"""
-        self.inject_numpy()
+        pass
 
 
 # Shorthands for legacy support

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ try:
 except ImportError:
     from distutils.core import setup
 
-
 dist = setup(
     name='cloudpickle',
     version='0.2.0.dev0',

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -4,6 +4,17 @@ import pytest
 import pickle
 import sys
 import functools
+import platform
+
+try:
+    # try importing numpy and scipy. These are not hard dependencies and
+    # tests should be skipped if these modules are not available
+    import numpy as np
+    import scipy.special as spp
+except ImportError:
+    np = None
+    spp = None
+
 
 from operator import itemgetter, attrgetter
 
@@ -143,6 +154,25 @@ class CloudPickleTest(unittest.TestCase):
     def test_partial(self):
         partial_obj = functools.partial(min, 1)
         self.assertEqual(pickle_depickle(partial_obj)(4), 1)
+
+    @pytest.mark.skipif(platform.python_implementation() == 'PyPy',
+                        reason="Skip numpy and scipy tests on PyPy")
+    def test_ufunc(self):
+        # test a numpy ufunc (universal function), which is a C-based function
+        # that is applied on a numpy array
+
+        if np:
+            # simple ufunc: np.add
+            self.assertEqual(pickle_depickle(np.add), np.add)
+        else:  # skip if numpy is not available
+            pass
+
+        if spp:
+            # custom ufunc: scipy.special.iv
+            self.assertEqual(pickle_depickle(spp.iv), spp.iv)
+        else:  # skip if scipy is not available
+            pass
+
 
     def test_save_unsupported(self):
         sio = StringIO()


### PR DESCRIPTION
Custom ufunc code was removed bc pickling of ufuncs were working without the custom ufunc code
Also, adds numpy and scipy to travis CPython builds through miniconda install

also, numpy and scipy tests are only run when modules are available
and the interpreter is not CPython