### PR TITLE
Include pickle load and loads into namespace

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -592,6 +592,10 @@ def dumps(obj, protocol=2):
 
     return file.getvalue()
 
+# including pickles unloading functions in this namespace
+load = pickle.load
+loads = pickle.loads
+
 
 #hack for __import__ not working as desired
 def subimport(name):


### PR DESCRIPTION
Allow users to import just cloudpickle to dump and load pickled data.

cloudpickle can be a drop-in replacement for pickle, for basic
functionality `import cloudpickle as pickle`.

Issue Ref: #36