### PR TITLE
Add test for pickle.loads into cloudpickle namespace

### DIFF
--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -47,11 +47,11 @@ class CloudPickleTest(unittest.TestCase):
         d = range(10)
         getter = itemgetter(1)
 
-        getter2 = pickle.loads(cloudpickle.dumps(getter))
+        getter2 = pickle_depickle(getter)
         self.assertEqual(getter(d), getter2(d))
 
         getter = itemgetter(0, 3)
-        getter2 = pickle.loads(cloudpickle.dumps(getter))
+        getter2 = pickle_depickle(getter)
         self.assertEqual(getter(d), getter2(d))
 
     def test_attrgetter(self):
@@ -60,18 +60,18 @@ class CloudPickleTest(unittest.TestCase):
                 return item
         d = C()
         getter = attrgetter("a")
-        getter2 = pickle.loads(cloudpickle.dumps(getter))
+        getter2 = pickle_depickle(getter)
         self.assertEqual(getter(d), getter2(d))
         getter = attrgetter("a", "b")
-        getter2 = pickle.loads(cloudpickle.dumps(getter))
+        getter2 = pickle_depickle(getter)
         self.assertEqual(getter(d), getter2(d))
 
         d.e = C()
         getter = attrgetter("e.a")
-        getter2 = pickle.loads(cloudpickle.dumps(getter))
+        getter2 = pickle_depickle(getter)
         self.assertEqual(getter(d), getter2(d))
         getter = attrgetter("e.a", "e.b")
-        getter2 = pickle.loads(cloudpickle.dumps(getter))
+        getter2 = pickle_depickle(getter)
         self.assertEqual(getter(d), getter2(d))
 
     # Regression test for SPARK-3415

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -184,7 +184,6 @@ class CloudPickleTest(unittest.TestCase):
         else:  # skip if scipy is not available
             pass
 
-
     def test_save_unsupported(self):
         sio = StringIO()
         pickler = cloudpickle.CloudPickler(sio, 2)
@@ -194,6 +193,10 @@ class CloudPickleTest(unittest.TestCase):
 
         assert "Cannot pickle objects of type" in str(excinfo.value)
 
+    def test_loads_namespace(self):
+        obj = 1, 2, 3, 4
+        returned_obj = cloudpickle.loads(cloudpickle.dumps(obj))
+        self.assertEqual(obj, returned_obj)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -23,6 +23,8 @@ try:
 except ImportError:
     from io import StringIO
 
+from io import BytesIO
+
 import cloudpickle
 
 from .testutils import subprocess_pickle_echo
@@ -196,6 +198,14 @@ class CloudPickleTest(unittest.TestCase):
     def test_loads_namespace(self):
         obj = 1, 2, 3, 4
         returned_obj = cloudpickle.loads(cloudpickle.dumps(obj))
+        self.assertEqual(obj, returned_obj)
+
+    def test_load_namespace(self):
+        obj = 1, 2, 3, 4
+        bio = BytesIO()
+        cloudpickle.dump(obj, bio)
+        bio.seek(0)
+        returned_obj = cloudpickle.load(bio)
         self.assertEqual(obj, returned_obj)
 
 if __name__ == '__main__':


### PR DESCRIPTION
+ There are no tests for `cloudpickle.dump`, therefore followed suit with `cloudpickle.load`.
+ Unsure what object to test with for `cloudpickle.loads`, therefore used a tuple `(1, 2, 3, 4)`.
+ Noticed that the `pickle_depickle` function was not used in earlier tests; simple search and replaced.