### PR TITLE
Add save_classmethod from https://github.com/uqfoundation/dill/pull/125

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -421,6 +421,11 @@ class CloudPickler(Pickler):
         self.save_reduce(property, (obj.fget, obj.fset, obj.fdel, obj.__doc__), obj=obj)
     dispatch[property] = save_property
 
+    def save_classmethod(self, obj):
+        self.save_reduce(type(obj), (obj.__func__,), obj=obj)
+    dispatch[classmethod] = save_classmethod
+    dispatch[staticmethod] = save_classmethod
+
     def save_itemgetter(self, obj):
         """itemgetter serializer (needed for namedtuple support)"""
         class Dummy:

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -422,7 +422,13 @@ class CloudPickler(Pickler):
     dispatch[property] = save_property
 
     def save_classmethod(self, obj):
-        self.save_reduce(type(obj), (obj.__func__,), obj=obj)
+        try:
+            orig_func = obj.__func__
+        except AttributeError:  # Python 2.6
+            orig_func = obj.__get__(None, object)
+            if isinstance(obj, classmethod):
+                orig_func = orig_func.__func__  # Unbind
+        self.save_reduce(type(obj), (orig_func,), obj=obj)
     dispatch[classmethod] = save_classmethod
     dispatch[staticmethod] = save_classmethod
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -219,5 +219,23 @@ class CloudPickleTest(unittest.TestCase):
         assert type(gen2(3)) == type(some_generator(3))
         assert list(gen2(3)) == list(range(3))
 
+    def test_classmethod(self):
+        class A(object):
+            @staticmethod
+            def test_sm():
+                return "sm"
+            @classmethod
+            def test_cm(cls):
+                return "cm"
+
+        sm = A.__dict__["test_sm"]
+        cm = A.__dict__["test_cm"]
+
+        A.test_sm = pickle_depickle(sm)
+        A.test_cm = pickle_depickle(cm)
+
+        self.assertEqual(A.test_sm(), "sm")
+        self.assertEqual(A.test_cm(), "cm")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is the fix for classmethods from https://github.com/uqfoundation/dill/pull/125 patched onto cloudpickle as requested in #40.