### PR TITLE
Support method_descriptor

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -359,10 +359,13 @@ class CloudPickler(Pickler):
 
     def save_instancemethod(self, obj):
         # Memoization rarely is ever useful due to python bounding
-        if PY3:
-            self.save_reduce(types.MethodType, (obj.__func__, obj.__self__), obj=obj)
+        if obj.__self__ is None:
+            self.save_reduce(getattr, (obj.im_class, obj.__name__))
         else:
-            self.save_reduce(types.MethodType, (obj.__func__, obj.__self__, obj.__self__.__class__),
+            if PY3:
+                self.save_reduce(types.MethodType, (obj.__func__, obj.__self__), obj=obj)
+            else:
+                self.save_reduce(types.MethodType, (obj.__func__, obj.__self__, obj.__self__.__class__),
                          obj=obj)
     dispatch[types.MethodType] = save_instancemethod
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -698,3 +698,18 @@ Note: These can never be renamed due to client compatibility issues"""
 def _getobject(modname, attribute):
     mod = __import__(modname, fromlist=[attribute])
     return mod.__dict__[attribute]
+
+
+""" Use copy_reg to extend global pickle definitions """
+
+if sys.version_info < (3, 4):
+    method_descriptor = type(str.upper)
+
+    def _reduce_method_descriptor(obj):
+        return (getattr, (obj.__objclass__, obj.__name__))
+
+    try:
+        import copy_reg as copyreg
+    except ImportError:
+        import copyreg
+    copyreg.pickle(method_descriptor, _reduce_method_descriptor)

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -237,5 +237,10 @@ class CloudPickleTest(unittest.TestCase):
         self.assertEqual(A.test_sm(), "sm")
         self.assertEqual(A.test_cm(), "cm")
 
+    def test_method_descriptors(self):
+        f = cloudpickle.loads(cloudpickle.dumps(str.upper))
+        self.assertEqual(f('abc'), 'ABC')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -238,8 +238,19 @@ class CloudPickleTest(unittest.TestCase):
         self.assertEqual(A.test_cm(), "cm")
 
     def test_method_descriptors(self):
-        f = cloudpickle.loads(cloudpickle.dumps(str.upper))
+        f = pickle_depickle(str.upper)
         self.assertEqual(f('abc'), 'ABC')
+
+    def test_instancemethods_without_self(self):
+        class F(object):
+            def f(self, x):
+                return x + 1
+
+        g = pickle_depickle(F.f)
+        self.assertEqual(g.__name__, F.f.__name__)
+        if sys.version_info[0] < 3:
+            self.assertEqual(g.im_class.__name__, F.f.im_class.__name__)
+        # self.assertEqual(g(F(), 1), 2)  # still fails
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously serializing bare class methods would fail in Python 2
Now it works fine.

    >>> cloudpickle.dumps(str.upper)

We accomplish this by extending pickle's reduce function registry.