### PR TITLE
Use codecov.io for code coverage reports in Travis

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+branch = True
+source = cloudpickle
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if __name__ == .__main__.:
+ignore_errors = True

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
-.coverage.*
+.coverage/.*
 .cache
 nosetests.xml
 coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,6 @@ install:
   - pip install .
   - pip install -r dev-requirements.txt
 script:
-  - PYTHONPATH='.:tests' py.test
+  - PYTHONPATH='.:tests' py.test --cov-config .coveragerc --cov=cloudpickle
+after_success:
+  - codecov

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/cloudpipe/cloudpickle.svg?branch=master
     )](https://travis-ci.org/cloudpipe/cloudpickle)
+[![codecov.io](https://codecov.io/github/cloudpipe/cloudpickle/coverage.svg?branch=master)](https://codecov.io/github/cloudpipe/cloudpickle?branch=master)
 
 `cloudpickle` makes it possible to serialize Python constructs not supported
 by the default `pickle` module from the Python standard library.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,5 @@
 pytest
 pytest-cov
 mock
+# Code coverage uploader for Travis:
+codecov


### PR DESCRIPTION
This commit configures the Travis build to emit test coverage reports and uses https://codecov.io to display coverage reports.

The current coverage is a bit low due to some dead code, but I propose to delete that in a followup patch.