### PR TITLE
Allow pickling of builtin methods

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -53,7 +53,6 @@ from functools import partial
 import itertools
 import dis
 import traceback
-import inspect
 
 if sys.version < '3':
     from pickle import Pickler
@@ -182,7 +181,7 @@ class CloudPickler(Pickler):
         if name is None:
             name = obj.__name__
         modname = pickle.whichmodule(obj, name)
-        #print('which gives %s %s %s' % (modname, obj, name))
+        # print('which gives %s %s %s' % (modname, obj, name))
         try:
             themodule = sys.modules[modname]
         except KeyError:

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -5,6 +5,7 @@ import pytest
 import pickle
 import sys
 import functools
+import itertools
 import platform
 import textwrap
 
@@ -290,6 +291,17 @@ class CloudPickleTest(unittest.TestCase):
 
     def test_NotImplemented(self):
         self.assertEqual(NotImplemented, pickle_depickle(NotImplemented))
+
+    @pytest.mark.skipif((3, 0) < sys.version_info < (3, 4),
+                        reason="fails due to pickle behavior in Python 3.0-3.3")
+    def test_builtin_function_without_module(self):
+        on = object.__new__
+        on_depickled = pickle_depickle(on)
+        self.assertEqual(type(on_depickled(object)), type(object()))
+
+        fi = itertools.chain.from_iterable
+        fi_depickled = pickle_depickle(fi)
+        self.assertEqual(list(fi([[1, 2], [3, 4]])), [1, 2, 3, 4])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This resolves #56, which found that things like `cloudpickle.dumps(itertools.chain.from_iterable)` and `cloudpickle.dumps(object.__new__)` failed because these builtin methods do not have a `__code__` attribute and `pickle.whichmodule` can't determine their module. The solution here is to intercept these things and send them to `save_reduce`.

I had to use slightly different solutions for Python 2.7 and >=3.4. I couldn't resolve it at all for 3.3: looks like doing so would require getting deep into the details of pickling. In 3.2 and 3.3, trying to unpickle the pickled method results in "NEWOBJ class argument has NULL tp_new error". So to avoid people pickling data and then being unable to unpickle it, the current version refuses to pickle these methods for those python versions.