### PR TITLE
Add support for weakref.ref type

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -90,6 +90,16 @@ def _builtin_type(name):
     return getattr(types, name)
 
 
+import weakref
+
+_SINGLETONS = dict((o, str(o)) for o in [weakref.ref])
+_SINGLETONS_REVERSE = dict((v, k) for k, v in _SINGLETONS.items())
+
+
+def _singleton(name):
+    return _SINGLETONS_REVERSE[name]
+
+
 class CloudPickler(Pickler):
 
     dispatch = Pickler.dispatch.copy()
@@ -109,6 +119,8 @@ class CloudPickler(Pickler):
             if 'recursion' in e.args[0]:
                 msg = """Could not pickle object as excessively deep recursion required."""
                 raise pickle.PicklingError(msg)
+            else:
+                raise
 
     def save_memoryview(self, obj):
         """Fallback to save_string"""
@@ -199,7 +211,7 @@ class CloudPickler(Pickler):
         # a builtin_function_or_method which comes in as an attribute of some
         # object (e.g., object.__new__, itertools.chain.from_iterable) will end
         # up with modname "__main__" and so end up here. But these functions
-        # have no __code__ attribute in CPython, so the handling for 
+        # have no __code__ attribute in CPython, so the handling for
         # user-defined functions below will fail.
         # So we pickle them here using save_reduce; have to do it differently
         # for different python versions.
@@ -354,6 +366,8 @@ class CloudPickler(Pickler):
         if obj.__module__ == "__builtin__" or obj.__module__ == "builtins":
             if obj in _BUILTIN_TYPE_NAMES:
                 return self.save_reduce(_builtin_type, (_BUILTIN_TYPE_NAMES[obj],), obj=obj)
+            if obj in _SINGLETONS:
+                return self.save_reduce(_singleton, (_SINGLETONS[obj],), obj=obj)
 
         if name is None:
             name = obj.__name__

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -289,6 +289,10 @@ class CloudPickleTest(unittest.TestCase):
     def test_Ellipsis(self):
         self.assertEqual(Ellipsis, pickle_depickle(Ellipsis))
 
+    def test_weakref(self):
+        import weakref
+        self.assertEqual(weakref.ref, pickle_depickle(weakref.ref))
+
     def test_NotImplemented(self):
         self.assertEqual(NotImplemented, pickle_depickle(NotImplemented))
 


### PR DESCRIPTION
Tornado 4.5 is using this in all coroutines.

I don't see a clear way to serialize it.  I've placed it in a global
dictionary of singletons.  I would be delighted to find another way
to do this.