### PR TITLE
Fix #71: make cloudpickle Python 3.6 compatible

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -320,10 +320,10 @@ class CloudPickler(Pickler):
         write(pickle.TUPLE)
         write(pickle.REDUCE)  # applies _fill_function on the tuple
 
-
-    _extract_code_globals_cache = (weakref.WeakKeyDictionary()
-                                   if sys.version_info >= (2, 7)
-                                   else {})
+    _extract_code_globals_cache = (
+        weakref.WeakKeyDictionary()
+        if sys.version_info >= (2, 7) and not hasattr(sys, "pypy_version_info")
+        else {})
 
     @classmethod
     def extract_code_globals(cls, co):

--- a/tests/cloudpickle_file_test.py
+++ b/tests/cloudpickle_file_test.py
@@ -85,7 +85,7 @@ class CloudPickleFileTests(unittest.TestCase):
             self.assertEquals(self.teststring, unpickled.read())
         os.remove(self.tmpfilepath)
 
-    @pytest.mark.skipif(sys.version_info > (2, 7),
+    @pytest.mark.skipif(sys.version_info >= (3,),
                         reason="only works on Python 2.x")
     def test_temp_file(self):
         with tempfile.NamedTemporaryFile(mode='ab+') as fp:

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -340,7 +340,7 @@ class CloudPickleTest(unittest.TestCase):
         nvars = 65537 + 258
         names = ['g%d' % i for i in range(1, nvars)]
         r = random.Random(42)
-        d = dict((name, r.randrange(100)) for name in names)
+        d = dict([(name, r.randrange(100)) for name in names])
         # def f(x):
         #     x = g1, g2, ...
         #     return zlib.crc32(bytes(bytearray(x)))
@@ -351,7 +351,7 @@ class CloudPickleTest(unittest.TestCase):
             x = {tup}
             return zlib.crc32(bytes(bytearray(x)))
         """.format(tup=', '.join(names))
-        exec(textwrap.dedent(code), d)
+        exec(textwrap.dedent(code), d, d)
         f = d['f']
         res = f()
         data = cloudpickle.dumps([f, f])


### PR DESCRIPTION
Also add a cache to the function which extracts global-referencing opcodes, speeding up repetitive pickling of non-tiny functions.