### PR TITLE
Assume modules with __file__ attribute are not dynamic

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -176,11 +176,14 @@ class CloudPickler(Pickler):
         """
         mod_name = obj.__name__
         # If module is successfully found then it is not a dynamically created module
-        try:
-            _find_module(mod_name)
+        if hasattr(obj, '__file__'):
             is_dynamic = False
-        except ImportError:
-            is_dynamic = True
+        else:
+            try:
+                _find_module(mod_name)
+                is_dynamic = False
+            except ImportError:
+                is_dynamic = True
 
         self.modules.add(obj)
         if is_dynamic:


### PR DESCRIPTION
Fixes https://github.com/cloudpipe/cloudpickle/issues/84

If a module has a `__file__` attribute then we assume that it is not
dynamically generated.  This allows the common case to be much faster
than otherwise.

However, it is not clear to me that this is always entirely safe.  Are there counter-examples where this could cause an issue?