### PR TITLE
recursive and unhashable closure

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -363,7 +363,10 @@ class CloudPickler(Pickler):
         save(_fill_function)  # skeleton function updater
         write(pickle.MARK)    # beginning of tuple that _fill_function expects
 
-        self._save_subimports(code, set(f_globals.values()) | set(closure))
+        self._save_subimports(
+            code,
+            itertools.chain(f_globals.values(), closure),
+        )
 
         # create a skeleton function object and memoize it
         save(_make_skel_func)

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -912,8 +912,13 @@ def _fill_function(func, globals, defaults, dict, closure_values):
     return func
 
 
-def _make_cell(value):
-    return (lambda: value).__closure__[0]
+def _make_empty_cell():
+    if False:
+        # trick the compiler into creating an empty cell in our lambda
+        cell = None
+        raise AssertionError('this route should not be executed')
+
+    return (lambda: cell).__closure__[0]
 
 
 def _make_skel_func(code, cell_count, base_globals=None):
@@ -926,7 +931,7 @@ def _make_skel_func(code, cell_count, base_globals=None):
     base_globals['__builtins__'] = __builtins__
 
     closure = (
-        tuple(_make_cell(None) for _ in range(cell_count))
+        tuple(_make_empty_cell() for _ in range(cell_count))
         if cell_count >= 0 else
         None
     )

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -118,7 +118,7 @@ def _make_cell_set_template_code():
             co.co_name,
             co.co_firstlineno,
             co.co_lnotab,
-            co.co_cellvars,
+            co.co_cellvars,  # this is the trickery
             (),
         )
     else:
@@ -136,7 +136,7 @@ def _make_cell_set_template_code():
             co.co_name,
             co.co_firstlineno,
             co.co_lnotab,
-            co.co_cellvars,
+            co.co_cellvars,  # this is the trickery
             (),
         )
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -154,6 +154,19 @@ class CloudPickleTest(unittest.TestCase):
         g2 = pickle_depickle(f2(2))
         self.assertEqual(g2(5), 240)
 
+    @pytest.mark.skipif(
+        supports_recursive_closure,
+        reason="Recursive closures shouldn't raise an exception if supported"
+    )
+    @pytest.mark.xfail
+    def test_recursive_closure_unsupported(self):
+        def f1():
+            def g():
+                return g
+            return g
+
+        pickle_depickle(f1())
+
     def test_unhashable_closure(self):
         def f():
             s = set((1, 2))  # mutable set is unhashable

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -155,6 +155,24 @@ class CloudPickleTest(unittest.TestCase):
         self.assertEqual(g2(5), 240)
 
     @pytest.mark.skipif(
+        not supports_recursive_closure,
+        reason='The C API is needed for recursively defined closures'
+    )
+    def test_closure_none_is_preserved(self):
+        def f():
+            """a function with no closure cells
+            """
+
+        self.assertIsNone(f.__closure__, msg='f actually has closure cells!')
+
+        g = pickle_depickle(f)
+
+        self.assertIsNone(
+            g.__closure__,
+            msg='g now has closure cells even though f does not',
+        )
+
+    @pytest.mark.skipif(
         supports_recursive_closure,
         reason="Recursive closures shouldn't raise an exception if supported"
     )

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -38,7 +38,7 @@ except ImportError:
 from io import BytesIO
 
 import cloudpickle
-from cloudpickle.cloudpickle import _find_module, supports_recursive_closure
+from cloudpickle.cloudpickle import _find_module
 
 from .testutils import subprocess_pickle_echo
 
@@ -133,10 +133,6 @@ class CloudPickleTest(unittest.TestCase):
         f2 = lambda x: f1(x) // b
         self.assertEqual(pickle_depickle(f2)(1), 1)
 
-    @pytest.mark.skipif(
-        not supports_recursive_closure,
-        reason='The C API is needed for recursively defined closures'
-    )
     def test_recursive_closure(self):
         def f1():
             def g():
@@ -154,10 +150,6 @@ class CloudPickleTest(unittest.TestCase):
         g2 = pickle_depickle(f2(2))
         self.assertEqual(g2(5), 240)
 
-    @pytest.mark.skipif(
-        not supports_recursive_closure,
-        reason='The C API is needed for recursively defined closures'
-    )
     def test_closure_none_is_preserved(self):
         def f():
             """a function with no closure cells
@@ -174,19 +166,6 @@ class CloudPickleTest(unittest.TestCase):
             g.__closure__ is None,
             msg='g now has closure cells even though f does not',
         )
-
-    @pytest.mark.skipif(
-        supports_recursive_closure,
-        reason="Recursive closures shouldn't raise an exception if supported"
-    )
-    def test_recursive_closure_unsupported(self):
-        def f1():
-            def g():
-                return g
-            return g
-
-        with pytest.raises(pickle.PicklingError):
-            pickle_depickle(f1())
 
     def test_unhashable_closure(self):
         def f():

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -179,14 +179,14 @@ class CloudPickleTest(unittest.TestCase):
         supports_recursive_closure,
         reason="Recursive closures shouldn't raise an exception if supported"
     )
-    @pytest.mark.xfail
     def test_recursive_closure_unsupported(self):
         def f1():
             def g():
                 return g
             return g
 
-        pickle_depickle(f1())
+        with pytest.raises(pickle.PicklingError):
+            pickle_depickle(f1())
 
     def test_unhashable_closure(self):
         def f():

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -38,7 +38,7 @@ except ImportError:
 from io import BytesIO
 
 import cloudpickle
-from cloudpickle.cloudpickle import _find_module
+from cloudpickle.cloudpickle import _find_module, _make_empty_cell, cell_set
 
 from .testutils import subprocess_pickle_echo
 
@@ -493,6 +493,19 @@ class CloudPickleTest(unittest.TestCase):
                    base64.b32encode(s).decode('ascii') +
                    "'))()")
         assert not subprocess.call([sys.executable, '-c', command])
+
+    def test_cell_manipulation(self):
+        cell = _make_empty_cell()
+
+        with pytest.raises(ValueError):
+            cell.cell_contents
+
+        ob = object()
+        cell_set(cell, ob)
+        self.assertTrue(
+            cell.cell_contents is ob,
+            msg='cell contents not set correctly',
+        )
 
 
 if __name__ == '__main__':

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -154,6 +154,18 @@ class CloudPickleTest(unittest.TestCase):
         g2 = pickle_depickle(f2(2))
         self.assertEqual(g2(5), 240)
 
+    def test_unhashable_closure(self):
+        def f():
+            s = set((1, 2))  # mutable set is unhashable
+
+            def g():
+                return len(s)
+
+            return g
+
+        g = pickle_depickle(f())
+        self.assertEqual(g(), 2)
+
     @pytest.mark.skipif(sys.version_info >= (3, 4)
                         and sys.version_info < (3, 4, 3),
                         reason="subprocess has a bug in 3.4.0 to 3.4.2")

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -163,12 +163,15 @@ class CloudPickleTest(unittest.TestCase):
             """a function with no closure cells
             """
 
-        self.assertIsNone(f.__closure__, msg='f actually has closure cells!')
+        self.assertTrue(
+            f.__closure__ is None,
+            msg='f actually has closure cells!',
+        )
 
         g = pickle_depickle(f)
 
-        self.assertIsNone(
-            g.__closure__,
+        self.assertTrue(
+            g.__closure__ is None,
             msg='g now has closure cells even though f does not',
         )
 


### PR DESCRIPTION
xref: #89, #86, #62

NOTE: This is based off of the work by @mehrdadn. I had a couple of ideas to improve performance but the core idea is theirs. I apologize for opening another PR, but it seemed easier than trying to communicate my idea without code.

Instead of serializing the empty cell objects, this change serializes just an integer which tells the receiver how man empty cells to create in `_make_skel_func`. This reduces the size of the serialized result, for example, given the function:

```python
def f():
    def g():
        return g
    return g
```

With #89:
```python
In [3]: len(dumps(f()))
Out[3]: 366
```

With this PR:
```python
In [3]: len(dumps(f()))
Out[3]: 321
```
The other (and much smaller) change is to remove the `PyCell_Set is not None` checks in favor of stub functions. This only affects pypy where these identity or nop functions should have very little cost, and it keeps the more complicated serialization function free of extra branches.

In order to fix the unhashable closure cells and globals, we use `itertools.chain` to walk over the values with the belief that duplicate values should be very rare and they will already be memoized.

UPDATE:

I am now serializing a -1 for the closure length if the `__closure__` is None. Now we will get a closure of None instead of an empty tuple on the other side.