### PR TITLE
BUG: Support WeakSets and ABCMeta instances.

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -859,7 +859,7 @@ class CloudPickler(Pickler):
     dispatch[type(NotImplemented)] = save_not_implemented
 
     # WeakSet was added in 2.7.
-    if sys.version_info >= (2, 7):
+    if hasattr(weakref, 'WeakSet'):
         def save_weakset(self, obj):
             self.save_reduce(weakref.WeakSet, (list(obj),))
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -858,6 +858,13 @@ class CloudPickler(Pickler):
     dispatch[type(Ellipsis)] = save_ellipsis
     dispatch[type(NotImplemented)] = save_not_implemented
 
+    # WeakSet was added in 2.7.
+    if sys.version_info >= (2, 7):
+        def save_weakset(self, obj):
+            self.save_reduce(weakref.WeakSet, (list(obj),))
+
+        dispatch[weakref.WeakSet] = save_weakset
+
     """Special functions for Add-on libraries"""
     def inject_addons(self):
         """Plug in system. Register additional pickling functions if modules already loaded"""

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -46,7 +46,7 @@ from cloudpickle.cloudpickle import _find_module, _make_empty_cell, cell_set
 from .testutils import subprocess_pickle_echo
 
 
-HAVE_WEAKSET = sys.version_info >= (2, 7)
+HAVE_WEAKSET = hasattr(weakref, 'WeakSet')
 
 
 def pickle_depickle(obj):

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -619,10 +619,8 @@ class CloudPickleTest(unittest.TestCase):
         self.assertEqual(depickled_class().foo(), 'it works!')
         self.assertEqual(depickled_instance.foo(), 'it works!')
 
-        # It should still be invalid to construct an instance of the abstract
-        # class without implementing its methods.
-        with self.assertRaises(TypeError):
-            depickled_base()
+        # assertRaises doesn't return a contextmanager in python 2.6 :(.
+        self.failUnlessRaises(TypeError, depickled_base)
 
         class DepickledBaseSubclass(depickled_base):
             def foo(self):


### PR DESCRIPTION
Fixes a bug where pickling instances of instances of ABCMeta (you read
that correctly) would fail because ABCMeta uses several (previously
unpicklable) WeakSets as caches.

We fix the issue by adding support for pickling WeakSets via
`save_reduce`.

Fixes #103.