### PR TITLE
Fix pickling when pytest is loaded.

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -384,7 +384,8 @@ class CloudPickler(Pickler):
                 # check if the package has any currently loaded sub-imports
                 prefix = x.__name__ + '.'
                 for name, module in sys.modules.items():
-                    if name.startswith(prefix):
+                    # Older versions of pytest will add a "None" module to sys.modules.
+                    if name is not None and name.startswith(prefix):
                         # check whether the function can address the sub-module
                         tokens = set(name[len(prefix):].split('.'))
                         if not tokens - set(code.co_names):


### PR DESCRIPTION
Older versions of pytest will add a "None" module to `sys.modules`.

This was removed rather recently pytest-dev/pytest#2106, so this PR prevents that old code from breaking things.