### PR TITLE
Catches the exception from pickle.whichmodule()

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -310,7 +310,12 @@ class CloudPickler(Pickler):
 
         if name is None:
             name = obj.__name__
-        modname = pickle.whichmodule(obj, name)
+        try:
+            # whichmodule() could fail, see
+            # https://bitbucket.org/gutworth/six/issues/63/importing-six-breaks-pickling
+            modname = pickle.whichmodule(obj, name)
+        except Exception:
+            modname = None
         # print('which gives %s %s %s' % (modname, obj, name))
         try:
             themodule = sys.modules[modname]
@@ -594,7 +599,12 @@ class CloudPickler(Pickler):
 
         modname = getattr(obj, "__module__", None)
         if modname is None:
-            modname = pickle.whichmodule(obj, name)
+            try:
+                # whichmodule() could fail, see
+                # https://bitbucket.org/gutworth/six/issues/63/importing-six-breaks-pickling
+                modname = pickle.whichmodule(obj, name)
+            except Exception:
+                modname = '__main__'
 
         if modname == '__main__':
             themodule = None


### PR DESCRIPTION
This PR proposes to port https://github.com/apache/spark/commit/d7223bb9fdc54edcc1a45cead9a71b5bac49b2ab in PySpark into cloudpickle.

In short, `pickle.whichmodule` could fail, for example, in case of `six` - https://bitbucket.org/gutworth/six/issues/63/importing-six-breaks-pickling and it looks failed in `getattr`.

In such case, it looks nicer just to use `__main__` for the module name, which I believe we use when we can't find the module rather than throwing an exception. True, it is rather a band-aid fix but I believe this could be more beneficial in practice.

Please check out the details in https://bitbucket.org/gutworth/six/issues/63/importing-six-breaks-pickling and https://issues.apache.org/jira/browse/SPARK-16077
