### PR TITLE
BUG: Fix bug pickling namedtuple.

### DIFF
--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1,7 +1,7 @@
 from __future__ import division
 
 import abc
-
+import collections
 import base64
 import functools
 import imp
@@ -700,6 +700,15 @@ class CloudPickleTest(unittest.TestCase):
     def test_function_module_name(self):
         func = lambda x: x
         self.assertEqual(pickle_depickle(func).__module__, func.__module__)
+
+    def test_namedtuple(self):
+        MyTuple = collections.namedtuple('MyTuple', ['a', 'b', 'c'])
+
+        t = MyTuple(1, 2, 3)
+        depickled_t = pickle_depickle(t)
+
+        self.assertEqual((depickled_t.a, depickled_t.b, depickled_t.c), (1, 2, 3))
+        self.assertEqual(vars(t), vars(depickled_t))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -702,13 +702,18 @@ class CloudPickleTest(unittest.TestCase):
         self.assertEqual(pickle_depickle(func).__module__, func.__module__)
 
     def test_namedtuple(self):
-        MyTuple = collections.namedtuple('MyTuple', ['a', 'b', 'c'])
 
+        MyTuple = collections.namedtuple('MyTuple', ['a', 'b', 'c'])
         t = MyTuple(1, 2, 3)
-        depickled_t = pickle_depickle(t)
+
+        depickled_t, depickled_MyTuple = pickle_depickle([t, MyTuple])
+        self.assertIsInstance(depickled_t, depickled_MyTuple)
 
         self.assertEqual((depickled_t.a, depickled_t.b, depickled_t.c), (1, 2, 3))
-        self.assertEqual(vars(t), vars(depickled_t))
+        self.assertEqual((depickled_t[0], depickled_t[1], depickled_t[2]), (1, 2, 3))
+
+        self.assertEqual(depickled_MyTuple.__name__, 'MyTuple')
+        self.assertTrue(issubclass(depickled_MyTuple, tuple))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -720,7 +720,7 @@ class CloudPickleTest(unittest.TestCase):
         # parameters for factories.  For example, on Python 3.3,
         # `tuple.__new__` is a default value for some methods of namedtuple.
         for t in list, tuple, set, frozenset, dict, object:
-            self.assertIs(pickle_depickle(t.__new__), t.__new__)
+            self.assertTrue(pickle_depickle(t.__new__) is t.__new__)
 
 
 if __name__ == '__main__':

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -715,5 +715,13 @@ class CloudPickleTest(unittest.TestCase):
         self.assertEqual(depickled_MyTuple.__name__, 'MyTuple')
         self.assertTrue(issubclass(depickled_MyTuple, tuple))
 
+    def test_builtin_type__new__(self):
+        # Functions occasionally take the __new__ of these types as default
+        # parameters for factories.  For example, on Python 3.3,
+        # `tuple.__new__` is a default value for some methods of namedtuple.
+        for t in list, tuple, set, frozenset, dict, object:
+            self.assertIs(pickle_depickle(t.__new__), t.__new__)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -707,7 +707,7 @@ class CloudPickleTest(unittest.TestCase):
         t = MyTuple(1, 2, 3)
 
         depickled_t, depickled_MyTuple = pickle_depickle([t, MyTuple])
-        self.assertIsInstance(depickled_t, depickled_MyTuple)
+        self.assertTrue(isinstance(depickled_t, depickled_MyTuple))
 
         self.assertEqual((depickled_t.a, depickled_t.b, depickled_t.c), (1, 2, 3))
         self.assertEqual((depickled_t[0], depickled_t[1], depickled_t[2]), (1, 2, 3))


### PR DESCRIPTION
Fixes a crash when trying to set `__dict__` onto a type when `__dict__`
is a property.

https://github.com/cloudpipe/cloudpickle/issues/111