### PR TITLE
Sets the missing module name when pickling a function

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -508,6 +508,7 @@ class CloudPickler(Pickler):
         save(f_globals)
         save(defaults)
         save(dct)
+        save(func.__module__)
         save(closure_values)
         write(pickle.TUPLE)
         write(pickle.REDUCE)  # applies _fill_function on the tuple
@@ -1001,13 +1002,14 @@ class _empty_cell_value(object):
         return cls.__name__
 
 
-def _fill_function(func, globals, defaults, dict, closure_values):
+def _fill_function(func, globals, defaults, dict, module, closure_values):
     """ Fills in the rest of function data into the skeleton function object
         that were created via _make_skel_func().
     """
     func.__globals__.update(globals)
     func.__defaults__ = defaults
     func.__dict__ = dict
+    func.__module__ = module
 
     cells = func.__closure__
     if cells is not None:

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -697,5 +697,9 @@ class CloudPickleTest(unittest.TestCase):
         result = g()
         self.assertEqual(1, result)
 
+    def test_function_module_name(self):
+        func = lambda x: x
+        self.assertEqual(pickle_depickle(func).__module__, func.__module__)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR proposes to port https://github.com/apache/spark/commit/ee913e6e2d58dfac20f3f06ff306081bd0e48066 in PySpark to `cloudpipe/cloudpickle`. For the full description, please refer [SPARK-13697](https://issues.apache.org/jira/browse/SPARK-13697).

In short, this change allow to keep the module as below:

**Before:**

```python
>>> import cloudpickle, pickle
>>> func = lambda x: x
>>> print(func.__module__)
__main__
>>> print(pickle.loads(cloudpickle.dumps(func)).__module__)
None
```

**After:**

```python
>>> import cloudpickle, pickle
>>> func = lambda x: x
>>> print(func.__module__)
__main__
>>> print(pickle.loads(cloudpickle.dumps(func)).__module__)
__main__
```

