### PR TITLE
Some cleanups, fix memoryview support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,7 @@ python:
   - "3.5"
   - "3.6"
   - "pypy"
-matrix:
-  include:
-    # 0.14.0 is the last version with the old categorical system
-    - python: 3.3
-      env: PANDAS_VERSION_STR="=0.14.0"
-    - python: 2.7
-      env: PANDAS_VERSION_STR="=0.14.0"
+
 # This disables sudo, but makes builds start much faster
 # See http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 sudo: false
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -13,5 +13,5 @@ then
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
     conda info -a
-    conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION numpy scipy pip pandas
+    conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION numpy scipy pip
 fi

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -854,11 +854,12 @@ def dump(obj, file, protocol=2):
 
 def dumps(obj, protocol=2):
     file = StringIO()
-
-    cp = CloudPickler(file,protocol)
-    cp.dump(obj)
-
-    return file.getvalue()
+    try:
+        cp = CloudPickler(file,protocol)
+        cp.dump(obj)
+        return file.getvalue()
+    finally:
+        file.close()
 
 # including pickles unloading functions in this namespace
 load = pickle.load

--- a/tests/cloudpickle_file_test.py
+++ b/tests/cloudpickle_file_test.py
@@ -4,11 +4,7 @@ import os
 import shutil
 import pickle
 import sys
-try:
-    from io import StringIO
-except ImportError:
-    # compat for Python 2.6
-    from StringIO import StringIO
+from io import StringIO
 
 import pytest
 from mock import patch, mock_open

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -420,8 +420,6 @@ class CloudPickleTest(unittest.TestCase):
     def test_NotImplemented(self):
         self.assertEqual(NotImplemented, pickle_depickle(NotImplemented))
 
-    @pytest.mark.skipif((3, 0) < sys.version_info < (3, 4),
-                        reason="fails due to pickle behavior in Python 3.0-3.3")
     def test_builtin_function_without_module(self):
         on = object.__new__
         on_depickled = pickle_depickle(on)

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -130,6 +130,10 @@ class CloudPickleTest(unittest.TestCase):
         except NameError:  # Python 3 does no longer support buffers
             pass
 
+    def test_memoryview(self):
+        buffer_obj = memoryview(b"Hello")
+        self.assertEqual(pickle_depickle(buffer_obj), buffer_obj.tobytes())
+
     def test_lambda(self):
         self.assertEqual(pickle_depickle(lambda: 1)(), 1)
 


### PR DESCRIPTION
A couple assorted cleanups:
* `save_global` can use the default implementation most of the time
* `save_buffer` and `save_memory` needn't call `Pickler.save_string` directly
* use `save_reduce` instead of dumping opcodes by hand where possible
* remove Pandas from CI setup since it's not used anywhere in the test suite

Also, memoryviews should obviously serialize as bytes, not str.