### PR TITLE
Preserve func.__qualname__ when defined

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -962,7 +962,6 @@ def _fill_function(*args):
         func = args[0]
         keys = ['globals', 'defaults', 'dict', 'closure_values']
         state = dict(zip(keys, args[1:]))
-        state['module'] = None
     elif len(args) == 6:
         # Backwards compat for cloudpickle v0.4.1, after which the function
         # state was passed as a dict to the _fill_function it-self.
@@ -975,7 +974,8 @@ def _fill_function(*args):
     func.__globals__.update(state['globals'])
     func.__defaults__ = state['defaults']
     func.__dict__ = state['dict']
-    func.__module__ = state['module']
+    if 'module' in state:
+        func.__module__ = state['module']
     if 'qualname' in state:
         func.__qualname__ = state['qualname']
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -703,6 +703,18 @@ class CloudPickleTest(unittest.TestCase):
         func = lambda x: x
         self.assertEqual(pickle_depickle(func).__module__, func.__module__)
 
+    def test_function_qualname(self):
+        def func(x):
+            return x
+        # Default __qualname__ attribute (Python 3 only)
+        if hasattr(func, '__qualname__'):
+            self.assertEqual(pickle_depickle(func).__qualname__,
+                             func.__qualname__)
+
+        # Mutated __qualname__ attribute
+        func.__qualname__ = '<modifiedlambda>'
+        self.assertEqual(pickle_depickle(func).__qualname__, func.__qualname__)
+
     def test_namedtuple(self):
 
         MyTuple = collections.namedtuple('MyTuple', ['a', 'b', 'c'])


### PR DESCRIPTION
This is a followup for #128 to address @pitrou's comment: https://github.com/cloudpipe/cloudpickle/pull/128#issuecomment-341457197.


This is backward compatible with 0.4.0 and 0.4.1 and should make it easier to be forward compatible with future versions shall we need to pass additional function metadata.

