### PR TITLE
[MRG] Regression on pickling classes from the __main__ module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+0.5.2
+=====
+
+- Fixed a regression: `AttributeError` when loading pickles that hold a
+  reference to a dynamically defined class from the `__main__` module.
+  ([issue #131]( https://github.com/cloudpipe/cloudpickle/issues/131)).
+
+
 0.5.1
 =====
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -639,11 +639,7 @@ class CloudPickler(Pickler):
                     return self.save_reduce(
                         _builtin_type, (_BUILTIN_TYPE_NAMES[obj],), obj=obj)
 
-            typ = type(obj)
-            if typ is not obj and isinstance(obj, (type, types.ClassType)):
-                return self.save_dynamic_class(obj)
-
-            raise
+            return self.save_dynamic_class(obj)
 
     dispatch[type] = save_global
     dispatch[types.ClassType] = save_global

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -629,11 +629,15 @@ class CloudPickler(Pickler):
         dispatched here.
         """
         try:
-            return Pickler.save_global(self, obj, name=name)
+            if obj.__module__ == "__main__":
+                raise ValueError("%r is defined in __main__" % obj)
+            else:
+                return Pickler.save_global(self, obj, name=name)
         except Exception:
             if obj.__module__ == "__builtin__" or obj.__module__ == "builtins":
                 if obj in _BUILTIN_TYPE_NAMES:
-                    return self.save_reduce(_builtin_type, (_BUILTIN_TYPE_NAMES[obj],), obj=obj)
+                    return self.save_reduce(
+                        _builtin_type, (_BUILTIN_TYPE_NAMES[obj],), obj=obj)
 
             typ = type(obj)
             if typ is not obj and isinstance(obj, (type, types.ClassType)):

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -628,11 +628,11 @@ class CloudPickler(Pickler):
         The name of this method is somewhat misleading: all types get
         dispatched here.
         """
+        if obj.__module__ == "__main__":
+            return self.save_dynamic_class(obj)
+
         try:
-            if obj.__module__ == "__main__":
-                raise ValueError("%r is defined in __main__" % obj)
-            else:
-                return Pickler.save_global(self, obj, name=name)
+            return Pickler.save_global(self, obj, name=name)
         except Exception:
             if obj.__module__ == "__builtin__" or obj.__module__ == "builtins":
                 if obj in _BUILTIN_TYPE_NAMES:

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -639,7 +639,11 @@ class CloudPickler(Pickler):
                     return self.save_reduce(
                         _builtin_type, (_BUILTIN_TYPE_NAMES[obj],), obj=obj)
 
-            return self.save_dynamic_class(obj)
+            typ = type(obj)
+            if typ is not obj and isinstance(obj, (type, types.ClassType)):
+                return self.save_dynamic_class(obj)
+
+            raise
 
     dispatch[type] = save_global
     dispatch[types.ClassType] = save_global

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -764,24 +764,29 @@ class CloudPickleTest(unittest.TestCase):
             def method(self, x):
                 return x
 
+        def f0(x):
+            return x ** 2
 
         def f1():
             return Foo
 
-
         def f2(x):
             return Foo().method(x)
-
 
         def f3():
             return Foo().method(CONSTANT)
 
-
         cloned = subprocess_pickle_echo(lambda x: x**2, protocol={protocol})
+        assert cloned(3) == 9
+
+        cloned = subprocess_pickle_echo(f0, protocol={protocol})
         assert cloned(3) == 9
 
         cloned = subprocess_pickle_echo(Foo, protocol={protocol})
         assert cloned().method(2) == Foo().method(2)
+
+        cloned = subprocess_pickle_echo(Foo(), protocol={protocol})
+        assert cloned.method(2) == Foo().method(2)
 
         cloned = subprocess_pickle_echo(f1, protocol={protocol})
         assert cloned()().method('a') == f1()().method('a')
@@ -792,8 +797,7 @@ class CloudPickleTest(unittest.TestCase):
         cloned = subprocess_pickle_echo(f3, protocol={protocol})
         assert cloned() == f3()
         """.format(protocol=self.protocol)
-        code = "\n".join(line[8:] for line in code.splitlines())
-        assert_run_python_script(code)
+        assert_run_python_script(textwrap.dedent(code))
 
     @pytest.mark.skipif(sys.version_info >= (3, 0),
                         reason="hardcoded pickle bytes for 2.7")

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -755,43 +755,44 @@ class CloudPickleTest(unittest.TestCase):
         # Check that callables defined in the __main__ module of a Python
         # script (or jupyter kernel) can be pickled / unpickled / executed.
         code = """\
-from testutils import subprocess_pickle_echo
+        from testutils import subprocess_pickle_echo
 
-CONSTANT = 42
+        CONSTANT = 42
 
-class Foo(object):
+        class Foo(object):
 
-    def method(self, x):
-        return x
-
-
-def f1():
-    return Foo
+            def method(self, x):
+                return x
 
 
-def f2(x):
-    return Foo().method(x)
+        def f1():
+            return Foo
 
 
-def f3():
-    return Foo().method(CONSTANT)
+        def f2(x):
+            return Foo().method(x)
 
 
-cloned = subprocess_pickle_echo(lambda x: x**2, protocol={protocol})
-assert cloned(3) == 9
+        def f3():
+            return Foo().method(CONSTANT)
 
-cloned = subprocess_pickle_echo(Foo, protocol={protocol})
-assert cloned().method(2) == Foo().method(2)
 
-cloned = subprocess_pickle_echo(f1, protocol={protocol})
-assert cloned()().method('a') == f1()().method('a')
+        cloned = subprocess_pickle_echo(lambda x: x**2, protocol={protocol})
+        assert cloned(3) == 9
 
-cloned = subprocess_pickle_echo(f2, protocol={protocol})
-assert cloned(2) == f2(2)
+        cloned = subprocess_pickle_echo(Foo, protocol={protocol})
+        assert cloned().method(2) == Foo().method(2)
 
-cloned = subprocess_pickle_echo(f3, protocol={protocol})
-assert cloned() == f3()
+        cloned = subprocess_pickle_echo(f1, protocol={protocol})
+        assert cloned()().method('a') == f1()().method('a')
+
+        cloned = subprocess_pickle_echo(f2, protocol={protocol})
+        assert cloned(2) == f2(2)
+
+        cloned = subprocess_pickle_echo(f3, protocol={protocol})
+        assert cloned() == f3()
         """.format(protocol=self.protocol)
+        code = "\n".join(line[8:] for line in code.splitlines())
         assert_run_python_script(code)
 
     @pytest.mark.skipif(sys.version_info >= (3, 0),

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -764,6 +764,8 @@ class CloudPickleTest(unittest.TestCase):
             def method(self, x):
                 return x
 
+        foo = Foo()
+
         def f0(x):
             return x ** 2
 
@@ -775,6 +777,9 @@ class CloudPickleTest(unittest.TestCase):
 
         def f3():
             return Foo().method(CONSTANT)
+
+        def f4(x):
+            return foo.method(x)
 
         cloned = subprocess_pickle_echo(lambda x: x**2, protocol={protocol})
         assert cloned(3) == 9
@@ -796,6 +801,9 @@ class CloudPickleTest(unittest.TestCase):
 
         cloned = subprocess_pickle_echo(f3, protocol={protocol})
         assert cloned() == f3()
+
+        cloned = subprocess_pickle_echo(f4, protocol={protocol})
+        assert cloned(2) == f4(2)
         """.format(protocol=self.protocol)
         assert_run_python_script(textwrap.dedent(code))
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -44,6 +44,7 @@ import cloudpickle
 from cloudpickle.cloudpickle import _find_module, _make_empty_cell, cell_set
 
 from .testutils import subprocess_pickle_echo
+from .testutils import assert_run_python_script
 
 
 HAVE_WEAKSET = hasattr(weakref, 'WeakSet')
@@ -287,19 +288,21 @@ class CloudPickleTest(unittest.TestCase):
         clone_class = pickle_depickle(SomeClass, protocol=self.protocol)
         self.assertEqual(clone_class(1).one(), 1)
         self.assertEqual(clone_class(5).some_method(41), 7)
-        clone_class = subprocess_pickle_echo(SomeClass)
+        clone_class = subprocess_pickle_echo(SomeClass, protocol=self.protocol)
         self.assertEqual(clone_class(5).some_method(41), 7)
 
         # pickle the class instances
         self.assertEqual(pickle_depickle(SomeClass(1)).one(), 1)
         self.assertEqual(pickle_depickle(SomeClass(5)).some_method(41), 7)
-        new_instance = subprocess_pickle_echo(SomeClass(5))
+        new_instance = subprocess_pickle_echo(SomeClass(5),
+                                              protocol=self.protocol)
         self.assertEqual(new_instance.some_method(41), 7)
 
         # pickle the method instances
         self.assertEqual(pickle_depickle(SomeClass(1).one)(), 1)
         self.assertEqual(pickle_depickle(SomeClass(5).some_method)(41), 7)
-        new_method = subprocess_pickle_echo(SomeClass(5).some_method)
+        new_method = subprocess_pickle_echo(SomeClass(5).some_method,
+                                            protocol=self.protocol)
         self.assertEqual(new_method(41), 7)
 
     def test_partial(self):
@@ -747,6 +750,49 @@ class CloudPickleTest(unittest.TestCase):
         # `tuple.__new__` is a default value for some methods of namedtuple.
         for t in list, tuple, set, frozenset, dict, object:
             self.assertTrue(pickle_depickle(t.__new__) is t.__new__)
+
+    def test_interactively_defined_function(self):
+        # Check that callables defined in the __main__ module of a Python
+        # script (or jupyter kernel) can be pickled / unpickled / executed.
+        code = """\
+from testutils import subprocess_pickle_echo
+
+CONSTANT = 42
+
+class Foo(object):
+
+    def method(self, x):
+        return x
+
+
+def f1():
+    return Foo
+
+
+def f2(x):
+    return Foo().method(x)
+
+
+def f3():
+    return Foo().method(CONSTANT)
+
+
+cloned = subprocess_pickle_echo(lambda x: x**2, protocol={protocol})
+assert cloned(3) == 9
+
+cloned = subprocess_pickle_echo(Foo, protocol={protocol})
+assert cloned().method(2) == Foo().method(2)
+
+cloned = subprocess_pickle_echo(f1, protocol={protocol})
+assert cloned()().method('a') == f1()().method('a')
+
+cloned = subprocess_pickle_echo(f2, protocol={protocol})
+assert cloned(2) == f2(2)
+
+cloned = subprocess_pickle_echo(f3, protocol={protocol})
+assert cloned() == f3()
+        """.format(protocol=self.protocol)
+        assert_run_python_script(code)
 
     @pytest.mark.skipif(sys.version_info >= (3, 0),
                         reason="hardcoded pickle bytes for 2.7")

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -30,7 +30,6 @@ def subprocess_pickle_echo(input_data, protocol=None):
     """
     pickled_input_data = dumps(input_data, protocol=protocol)
     cmd = [sys.executable, __file__]  # run then pickle_echo() in __main__
-    # cwd = os.getcwd()
     cloudpickle_repo_folder = op.normpath(
         op.join(op.dirname(__file__), '..'))
     cwd = cloudpickle_repo_folder

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,11 +1,8 @@
 import sys
 import os
+import os.path as op
 import tempfile
-from subprocess import Popen
-from subprocess import check_output
-from subprocess import PIPE
-from subprocess import STDOUT
-from subprocess import CalledProcessError
+from subprocess import Popen, check_output, PIPE, STDOUT, CalledProcessError
 
 from cloudpickle import dumps
 from pickle import loads
@@ -79,14 +76,17 @@ def assert_run_python_script(source_code, timeout=5):
     anything on stderr or stdout.
     """
     fd, source_file = tempfile.mkstemp(suffix='_src_test_cloudpickle.py')
+    os.close(fd)
     try:
-        with open(fd, 'wb') as f:
+        with open(source_file, 'wb') as f:
             f.write(source_code.encode('utf-8'))
+        cloudpickle_repo_folder = op.normpath(
+            op.join(op.dirname(__file__), '..'))
 
         cmd = [sys.executable, source_file]
-        pythonpath = "{cwd}/tests:{cwd}".format(cwd=os.getcwd())
+        pythonpath = "{src}/tests:{src}".format(src=cloudpickle_repo_folder)
         kwargs = {
-            'cwd': os.getcwd(),
+            'cwd': cloudpickle_repo_folder,
             'stderr': STDOUT,
             'env': {'PYTHONPATH': pythonpath},
         }

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -30,8 +30,13 @@ def subprocess_pickle_echo(input_data, protocol=None):
     """
     pickled_input_data = dumps(input_data, protocol=protocol)
     cmd = [sys.executable, __file__]  # run then pickle_echo() in __main__
-    cwd = os.getcwd()
-    proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, cwd=cwd)
+    # cwd = os.getcwd()
+    cloudpickle_repo_folder = op.normpath(
+        op.join(op.dirname(__file__), '..'))
+    cwd = cloudpickle_repo_folder
+    pythonpath = "{src}/tests:{src}".format(src=cloudpickle_repo_folder)
+    env = {'PYTHONPATH': pythonpath}
+    proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, cwd=cwd, env=env)
     try:
         comm_kwargs = {}
         if timeout_supported:
@@ -80,10 +85,9 @@ def assert_run_python_script(source_code, timeout=5):
     try:
         with open(source_file, 'wb') as f:
             f.write(source_code.encode('utf-8'))
+        cmd = [sys.executable, source_file]
         cloudpickle_repo_folder = op.normpath(
             op.join(op.dirname(__file__), '..'))
-
-        cmd = [sys.executable, source_file]
         pythonpath = "{src}/tests:{src}".format(src=cloudpickle_repo_folder)
         kwargs = {
             'cwd': cloudpickle_repo_folder,


### PR DESCRIPTION
This PR aims to fix the regression reported in #131 and that affects 0.4.2 and later. Right now there is is just a non-regression test to reproduce the problem.

I believe the regression was silently introduced by @pitrou's cleanups in #122 although I am not 100% sure yet because this code is quite complex.