### PR TITLE
[WIP] No-copy semantics for large memoryviews

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -252,7 +252,7 @@ else:
                 yield op, instr.arg
 
 
-def _memoryview_from_bytes(data, format, readonly):
+def _memoryview_from_bytes(data, format, readonly, shape):
     if not readonly:
         # Forcibly render the recently unpickled bytes buffer writable:
         # this is a violation of the immutability of a Python bytes object but
@@ -270,7 +270,7 @@ def _memoryview_from_bytes(data, format, readonly):
         # A memoryview of a bytes object is readonly by default.
         view = memoryview(data)
     if PY_MAJOR_MINOR >= (3, 5) or (PY_MAJOR_MINOR == (3, 4) and readonly):
-        return view.cast('B').cast(format)
+        return view.cast('B').cast(format, shape)
     else:
         # Python 2.7 does not support casting and Python 3.4 has a bug when
         # casting buffers from ctypes: # https://bugs.python.org/issue19803
@@ -405,6 +405,7 @@ class CloudPickler(Pickler):
             self.save_bytes(obj, skip_memoize=True)
         self.save(obj.format)
         self.save(obj.readonly)
+        self.save(obj.shape)
         self.write(pickle.TUPLE)
         self.write(pickle.REDUCE)
         self.memoize(obj)

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -61,6 +61,8 @@ import types
 import weakref
 
 
+RUNNING_CPYTHON = platform.python_implementation() == 'CPython'
+
 # cloudpickle is meant for inter process communication: we expect all
 # communicating processes to run the same Python version hence we favor
 # communication speed over compatibility:
@@ -270,7 +272,7 @@ class _Py2StrStruct(ctypes.Structure):
 
 def _is_safe_to_mutate(data_holder):
     """Helper function, see _memoryview_from_bytes for details."""
-    if platform.python_implementation() != 'CPython':
+    if not RUNNING_CPYTHON:
         # sys.getrefcount and ob_sstate are not always available on other
         # platforms (e.g. PyPy): better be conservative.
         return False

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -52,7 +52,7 @@ import logging
 import opcode
 import operator
 import pickle
-import struct
+from struct import pack
 import sys
 import traceback
 import types
@@ -277,7 +277,7 @@ class _Framer:
                 # file object for the frame opcode with the size of the
                 # frame. The concatenation is expected to be less expensive
                 # than issuing an additional call to write.
-                write(pickle.FRAME + struct.pack("<Q", len(data)))
+                write(pickle.FRAME + pack("<Q", len(data)))
 
                 # Issue a separate call to write to append the frame
                 # contents without concatenation to the above to avoid a
@@ -347,17 +347,17 @@ class CloudPickler(Pickler):
                     self.save_reduce(bytes, (), obj=obj)
                 else:
                     self.save_reduce(codecs.encode,
-                                    (str(obj, 'latin1'), 'latin1'), obj=obj)
+                                     (str(obj, 'latin1'), 'latin1'), obj=obj)
                 return
             n = len(obj)
             if n <= 0xff:
-                self.write(pickle.SHORT_BINBYTES + struct.pack("<B", n) + obj)
+                self.write(pickle.SHORT_BINBYTES + pack("<B", n) + obj)
             elif n > 0xffffffff and self.proto >= 4:
-                self._write_large_bytes(pickle.BINBYTES8 + struct.pack("<Q", n), obj)
+                self._write_large_bytes(pickle.BINBYTES8 + pack("<Q", n), obj)
             elif n >= self.framer._FRAME_SIZE_TARGET:
-                self._write_large_bytes(pickle.BINBYTES + struct.pack("<I", n), obj)
+                self._write_large_bytes(pickle.BINBYTES + pack("<I", n), obj)
             else:
-                self.write(pickle.BINBYTES + struct.pack("<I", n) + obj)
+                self.write(pickle.BINBYTES + pack("<I", n) + obj)
             self.memoize(obj)
         dispatch[bytes] = save_bytes
 
@@ -721,7 +721,7 @@ class CloudPickler(Pickler):
         return self.save_function(obj)
     dispatch[types.BuiltinFunctionType] = save_builtin_function
 
-    def save_global(self, obj, name=None, pack=struct.pack):
+    def save_global(self, obj, name=None, pack=pack):
         """
         Save a "global".
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -277,12 +277,11 @@ def _is_safe_to_mutate(data_holder):
         # platforms (e.g. PyPy): better be conservative.
         return False
 
-    # If the following call to sys.getrefcount returns 2 it means that
-    # there is one reference from data_holder and one from the temporary
-    # arguments datastructure of the sys.getrefcount call. It is therefore
-    # safe to reuse the memory buffer of the bytes object as writeable
-    # buffer to back the memoryview: this buffer is no longer reachable
-    # from anywhere else.
+    # If the following call to sys.getrefcount returns 2, it means that there
+    # is one reference from data_holder and one from the temporary arguments
+    # datastructure of the sys.getrefcount call. It is therefore safe to reuse
+    # the memory buffer of the bytes object as writeable buffer to back the
+    # memoryview: this buffer is no longer reachable from anywhere else.
     safe_to_mutate = sys.getrefcount(data_holder[0]) <= 2
     data = data_holder[0]
     if safe_to_mutate and isinstance(data, str):
@@ -415,8 +414,10 @@ class _Framer:
         # object. Be careful not to concatenate the header and the payload
         # prior to calling 'write' as we do not want to allocate a large
         # temporary bytes object.
-        # We intentionally do not insert a protocol 4 frame opcode to make
-        # it possible to optimize file.read calls in the loader.
+        # We intentionally do not insert a protocol 4 frame opcode to make it
+        # possible to optimize file.read calls in the loader and pass the
+        # resulting bytes as a preallocated data buffer for more complex
+        # datastructures such as memoryviews or numpy arrays.
         write(header)
         write(payload)
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -265,7 +265,7 @@ def _memoryview_from_bytes(data, format, readonly):
     else:
         view = memoryview(data)
     if hasattr(view, 'cast'):
-        return view.cast(format)
+        return view.cast('B').cast(format)
     else:
         return view
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -331,8 +331,8 @@ def _memoryview_from_bytes(data_holder, format, readonly, shape, **kwargs):
             addr = ctypes.addressof(buffer.contents)
             array = (ctypes.c_char * len(data)).from_address(addr)
             # Store a reference to the backing bytes object to make GC work
-            # correctly. We hide the object itself in a closure to hide
-            # it from the unsuspecting users.
+            # correctly. We hide the object itself in a closure to prevent
+            # unsuspecting users to access it.
 
             def _hidden_buffer_ref():
                 raise TypeError("Access to mutable buffer with id %d is unsafe"

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -297,8 +297,11 @@ def _memoryview_from_bytes(data_holder, format, readonly, shape, **kwargs):
     # datastructure of the sys.getrefcount call. It is therefore safe to reuse
     # the memory buffer of the bytes object as writeable buffer to back the
     # memoryview: this buffer is no longer unreachable from anywhere else.
+    # Note under Python 3, single byte bytes can be mapped to singletons
+    # which are not safe to mutate.
     if hasattr(sys, 'getrefcount'):
-        safe_to_mutate = sys.getrefcount(data_holder[0]) <= 2
+        safe_to_mutate = (sys.getrefcount(data_holder[0]) <= 2
+                          and len(data_holder[0]) > 1)
     else:
         # PyPy does not use reference counting. Is there a way to detect if
         # a bytes objects can be mutated safely?

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -268,7 +268,8 @@ class _Py2StrStruct(ctypes.Structure):
         return self.ob_sstate != 0
 
 
-def _safe_to_mutate(data_holder):
+def _is_safe_to_mutate(data_holder):
+    """Helper function, see _memoryview_from_bytes for details."""
     if platform.python_implementation() != 'CPython':
         # sys.getrefcount and ob_sstate are not always available on other
         # platforms (e.g. PyPy): better be conservative.
@@ -320,7 +321,7 @@ def _memoryview_from_bytes(data_holder, format, readonly, shape, **kwargs):
     **kwargs are left ignored. Those are used to add flexibility to implement
     backward compatible changes in future versions of cloudpickle.
     """
-    safe_to_mutate = _safe_to_mutate(data_holder)
+    safe_to_mutate = _is_safe_to_mutate(data_holder)
     data = data_holder[0]
     del data_holder[:]
     if readonly:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,5 +8,5 @@ codecov
 
 # nocopy tests with pydata libraries
 numpy
-pandas; platform_python_implementation != "PyPy" and python_version >= '3.5'
+pandas; platform_python_implementation != "PyPy"
 scipy; platform_python_implementation != "PyPy" and python_version >= '3.5'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,6 @@ mock
 psutil
 # Code coverage uploader for Travis:
 codecov
+
+# nocopy tests with pydata libraries
+numpy

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,5 +2,6 @@
 pytest
 pytest-cov
 mock
+psutil
 # Code coverage uploader for Travis:
 codecov

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,5 +8,5 @@ codecov
 
 # nocopy tests with pydata libraries
 numpy
-pandas; platform_python_implementation != "PyPy"
+pandas; platform_python_implementation != "PyPy" and python_version >= '3.5'
 scipy; platform_python_implementation != "PyPy" and python_version >= '3.5'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,3 +8,5 @@ codecov
 
 # nocopy tests with pydata libraries
 numpy
+pandas; platform_python_implementation != "PyPy"
+scipy; platform_python_implementation != "PyPy"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,5 +8,5 @@ codecov
 
 # nocopy tests with pydata libraries
 numpy
-pandas; platform_python_implementation != "PyPy"
-scipy; platform_python_implementation != "PyPy"
+pandas; platform_python_implementation != "PyPy" and python_version >= '3.5'
+scipy; platform_python_implementation != "PyPy" and python_version >= '3.5'

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1057,7 +1057,10 @@ def test_nocopy_pydata():
     def reduce_ndarray(a):
         """Memoryview based reducer for numpy arrays"""
         if a.flags.f_contiguous:
-            # convert to c-contiguous to benefit from nocopy semantics.
+            # Transposing a F-contiguous array makes it possible to take
+            # a C-contiguous memoryview of it so as to benefit from nocopy
+            # semantics. The array will be transposed by to its original layout
+            # at unpickling time by array_builder.
             a = a.T
             transpose = True
         else:

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -173,6 +173,8 @@ class CloudPickleTest(unittest.TestCase):
         self.assertEqual(pickle_depickle(buffer_obj, protocol=self.protocol),
                          buffer_obj.tobytes())
 
+    @pytest.mark.skipif(platform.python_implementation() == 'PyPy',
+                        reason="cast is broken on PyPy < 5.9.0")
     def test_complex_memoryviews(self):
         # Use numpy to generate complex memory layouts to be able to test the
         # preservation of all memoryview attributes. Note that cloudpickle
@@ -1034,15 +1036,15 @@ def test_nocopy_pydata():
     pd = pytest.importorskip("pandas")
     sp = pytest.importorskip("scipy.sparse")
 
-    mem_tol = 30e6
-    shape = (int(1e5), 1000)
+    mem_tol = 50e6  # 50 MB
+    shape = (int(2e5), 100)
     data = np.arange(np.prod(shape)).reshape(shape)
     data_with_zeros = data.copy()
     data_with_zeros[::2] = 0
     csr = sp.csr_matrix(data_with_zeros)
 
     large_pydata_objects = [
-        (data, data.nbytes),
+        (data, data.nbytes),  # 160 MB
         (data.T, data.nbytes),
         (pd.DataFrame(data), data.nbytes),
         (csr, csr.indptr.nbytes + csr.indices.nbytes + csr.data.nbytes),

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -180,11 +180,10 @@ class CloudPickleTest(unittest.TestCase):
         # preservation of all memoryview attributes. Note that cloudpickle
         # does not guarantee nocopy semantics for all of those cases but
         # it should reconstruct the same memory layout in any-case.
-        # np = pytest.importorskip("numpy")
-        import numpy as np
+        np = pytest.importorskip("numpy")
         arrays = [
             np.arange(12).reshape(3, 4),
-            np.arange(12).reshape(3, 4).astype(np.float32),
+            np.arange(12000).reshape(3000, 4).astype(np.float32),
         ]
         if cloudpickle.PY3:
             # There is a bug when calling .tobytes() on non-c-contiguous numpy

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -865,6 +865,8 @@ class CloudPickleTest(unittest.TestCase):
         self.assertEquals(42, cloudpickle.loads(pickled)(42))
 
     def test_nocopy_bytes(self):
+        if self.protocol < 3:
+            pytest.skip("test_nocopy_bytes requires protocol 3 or more")
         sink = CountingByteSink()
         biggish_data = b'0' * int(2e8)  # 200 MB
         pickler = cloudpickle.CloudPickler(sink, protocol=self.protocol)

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -920,7 +920,7 @@ def test_nocopy_readonly_bytes(tmpdir):
         # a single binary buffer
         # XXX: the 'newly_allocated < 2 * size' check is too lax
         newly_allocated = monitor.peak_mem - monitor.base_mem
-        assert size <= newly_allocated < 2 * size
+        assert 0.9 * size < newly_allocated < 2 * size
 
         assert len(reconstructed) == len(biggish_data)
         if biggish_data is biggish_data_bytes:

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -898,7 +898,7 @@ class Protocol2CloudPickleTest(CloudPickleTest):
 def test_nocopy_readonly_bytes(tmpdir):
     tmpfile = str(tmpdir.join('biggish.pkl'))
     mem_tol = int(5e7)  # 50 MB
-    size = int(2e8)  # 200 MB
+    size = int(5e8)  # 500 MB
     biggish_data_bytes = b'0' * size
     biggish_data_view = memoryview(biggish_data_bytes)
     for biggish_data in [biggish_data_bytes, biggish_data_view]:
@@ -940,9 +940,11 @@ def test_nocopy_readonly_bytes(tmpdir):
 def test_nocopy_writable_memoryview(tmpdir):
     tmpfile = str(tmpdir.join('biggish.pkl'))
     mem_tol = int(5e7)  # 50 MB
-    size = int(2e8)  # 200 MB
+    size = int(5e8)  # 500 MB
     biggish_array = array.array('l', range(size // 8))
     biggish_array_view = memoryview(biggish_array)
+    assert not biggish_array_view.readonly
+
     with open(tmpfile, 'wb') as f:
         with PeakMemoryMonitor() as monitor:
             cloudpickle.dump(biggish_array_view, f)
@@ -967,5 +969,4 @@ def test_nocopy_writable_memoryview(tmpdir):
     assert reconstructed.nbytes == size
     assert not reconstructed.readonly
     assert reconstructed.format == biggish_array_view.format
-    for a, b in zip(reconstructed, range(size // 8)):
-        assert a == b
+    assert reconstructed == biggish_array_view

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -891,11 +891,11 @@ class Protocol2CloudPickleTest(CloudPickleTest):
     protocol = 2
 
 
-@pytest.mark.skipif(sys.version_info[:2] < (3, 5),
-                    reason="nocopy memoryview only supprted on Python 3.5+")
+@pytest.mark.skipif(sys.version_info[:2] < (3, 4),
+                    reason="nocopy memoryview only supported on Python 3.4+")
 @pytest.mark.skipif(platform.python_implementation() == 'PyPy',
                     reason="memoryview.c_contiguous is missing")
-def test_nocopy_bytes(tmpdir):
+def test_nocopy_readonly_bytes(tmpdir):
     tmpfile = str(tmpdir.join('biggish.pkl'))
     size = int(2e8)  # 200 MB
     biggish_data_bytes = b'0' * size

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -148,8 +148,11 @@ class CloudPickleTest(unittest.TestCase):
         assert buffer_obj.format == 'l'
         cloned = pickle_depickle(buffer_obj, protocol=self.protocol)
         self.assertEqual(cloned.tobytes(), buffer_obj.tobytes())
-        assert cloned.format == 'l'
         assert not cloned.readonly
+
+        if sys.version_info >= (3, 5):
+            # Python 3.4 is affected by https://bugs.python.org/issue19803
+            assert cloned.format == 'l'
 
     def test_large_memoryview(self):
         buffer_obj = memoryview(b"Hello!" * int(1e7))

--- a/tests/memoryview_test.py
+++ b/tests/memoryview_test.py
@@ -1,4 +1,6 @@
 import sys
+import platform
+from cloudpickle.cloudpickle import _safe_to_mutate
 from cloudpickle.cloudpickle import _memoryview_from_bytes
 from cloudpickle.cloudpickle import _Py2StrStruct
 import pytest
@@ -22,6 +24,7 @@ def test_safe_mutable_bytes():
     # the _memoryview_from_bytes function can safely reuse the memory
     # allocated for the bytes object to expose it as a mutable buffer to back
     # the memoryview.
+    assert _safe_to_mutate(buffer_holder)
     view = _memoryview_from_bytes(buffer_holder, 'B', False, (buffer_size,))
     assert not view.readonly
     assert len(buffer_holder) == 0
@@ -41,7 +44,14 @@ def test_safe_mutable_bytes():
 
 def test_never_mutate_singleton_bytes():
     for i in range(256):
-        buffer_holder = [bytes([i])]
+        if sys.version_info[0] >= 3:
+            buffer_holder = [bytes([i])]
+        else:
+            buffer_holder = [chr(i)]
+        assert not _safe_to_mutate(buffer_holder)
+
+        # In this case, a new read-write buffer is allocated to back the
+        # memoryview.
         view = _memoryview_from_bytes(buffer_holder, 'B', False, (1,))
         assert not view.readonly
         if hasattr(view, 'obj'):
@@ -54,7 +64,9 @@ def test_unsafe_mutable_bytes_with_external_references():
 
     # The local 'buffer' variable still holds a reference to the bytes object
     # instance: _memoryview_from_bytes cannot safely reuse the same buffer.
-    # Instead new mutable memory is allocated to back the buffer.
+    assert not _safe_to_mutate(buffer_holder)
+
+    # Instead new mutable memory is allocated to back the buffer:
     view = _memoryview_from_bytes(buffer_holder, 'B', False, (3,))
     assert not view.readonly
     assert len(buffer_holder) == 0
@@ -70,10 +82,15 @@ def test_unsafe_mutable_bytes_with_external_references():
 
 @pytest.mark.skipif(sys.version_info[0] != 2,
                     reason="Test relies on Python 2 str interning")
+@pytest.mark.skipif(platform.python_implementation != 'CPython',
+                    reason="Test requires access to ob_sstate field.")
 def test_py2_interned_string_detection():
-    s1 = (lambda x: 'some python 2 ' + x.encode('ascii'))(u'string')
-    s2 = intern('some python 2 string')
-    s3 = intern('some python 2 string')
+    def process_str(original):
+        """Return non-interned version of original str object"""
+        return ' '.join(x for x in original.split(' '))
+    s1 = process_str('some python 2 str')
+    s2 = intern('some python 2 str')
+    s3 = intern('some python 2 str')
     assert s1 == s2
     assert s1 is not s2
     assert s2 is s3
@@ -81,11 +98,23 @@ def test_py2_interned_string_detection():
     assert _Py2StrStruct.from_address(id(s2)).is_interned()
     assert _Py2StrStruct.from_address(id(s3)).is_interned()
 
+    # Interned CPython str buffers are never safe to mutate even without
+    # external references.
+    buffer_holder = [intern(process_str('other python 2 str'))]
+    assert not _safe_to_mutate(buffer_holder)
+
+    # Non-interned CPython str buffers without any external references are
+    # safe to mutate:
+    buffer_holder = [process_str('other python 2 str')]
+    assert _safe_to_mutate(buffer_holder)
+
 
 @pytest.mark.skipif(sys.version_info[0] != 2,
                     reason="Test relies on Python 2 str interning")
 def test_unsafe_mutable_bytes_with_python_2_interning():
     buffer_holder = [intern(u"\x01\x02\x03".encode('ascii'))]
+
+    assert not _safe_to_mutate(buffer_holder)
     view = _memoryview_from_bytes(buffer_holder, 'B', False, (3,))
     assert not view.readonly
     assert len(buffer_holder) == 0
@@ -96,4 +125,3 @@ def test_unsafe_mutable_bytes_with_python_2_interning():
     # Mutate the view pointing the to the original buffer
     view[:] = b'\x00\x00\x00'
     assert interned_buffer == b'\x01\x02\x03'
-

--- a/tests/memoryview_test.py
+++ b/tests/memoryview_test.py
@@ -1,0 +1,99 @@
+import sys
+from cloudpickle.cloudpickle import _memoryview_from_bytes
+from cloudpickle.cloudpickle import _Py2StrStruct
+import pytest
+
+
+@pytest.mark.skipif(sys.version_info[:2] == (3, 4),
+                    reason="https://bugs.python.org/issue19803")
+def test_safe_mutable_bytes():
+    if sys.version_info[0] >= 3:
+        buffer = bytes([1, 2, 3])
+    else:
+        # Make the buffer large enough to avoid Python 2 string interning.
+        buffer = (u'0123' * 100000).encode('ascii')
+    buffer_id = id(buffer)
+    buffer_size = len(buffer)
+    buffer_holder = [buffer]
+    # Delete the local direct reference to the buffer
+    del buffer
+
+    # There are no external reference to the bytes object in buffer_holder,
+    # the _memoryview_from_bytes function can safely reuse the memory
+    # allocated for the bytes object to expose it as a mutable buffer to back
+    # the memoryview.
+    view = _memoryview_from_bytes(buffer_holder, 'B', False, (buffer_size,))
+    assert not view.readonly
+    assert len(buffer_holder) == 0
+
+    # CPython 2 and PyPy do not expose the obj attribute.
+    if hasattr(view, 'obj'):
+        # The last reference to the original bytes object is hold in a closure
+        # to discourage direct access by the user:
+        with pytest.raises(TypeError) as exc_info:
+            view.obj._hidden_buffer_ref()
+            msg = "Access to mutable buffer with id %d is unsafe" % buffer_id
+            assert exc_info.value.args[0] == msg
+
+    # It's possible to mutate the content of the buffer
+    view[:] = b'\x00' * buffer_size
+
+
+def test_never_mutate_singleton_bytes():
+    for i in range(256):
+        buffer_holder = [bytes([i])]
+        view = _memoryview_from_bytes(buffer_holder, 'B', False, (1,))
+        assert not view.readonly
+        if hasattr(view, 'obj'):
+            assert not hasattr(view.obj, '_hidden_buffer_ref')
+
+
+def test_unsafe_mutable_bytes_with_external_references():
+    buffer = u"\x01\x02\x03".encode('ascii')
+    buffer_holder = [buffer]
+
+    # The local 'buffer' variable still holds a reference to the bytes object
+    # instance: _memoryview_from_bytes cannot safely reuse the same buffer.
+    # Instead new mutable memory is allocated to back the buffer.
+    view = _memoryview_from_bytes(buffer_holder, 'B', False, (3,))
+    assert not view.readonly
+    assert len(buffer_holder) == 0
+    if hasattr(view, 'obj'):
+        # CPython 2 and PyPy does not expose the 'obj attribute'.
+        assert not hasattr(view.obj, '_hidden_buffer_ref')
+
+    # Check that changing the content of the view does not change the content
+    # of original buffer:
+    view[:] = b'\x00\x00\x00'
+    assert buffer == b"\x01\x02\x03"
+
+
+@pytest.mark.skipif(sys.version_info[0] != 2,
+                    reason="Test relies on Python 2 str interning")
+def test_py2_interned_string_detection():
+    s1 = (lambda x: 'some python 2 ' + x.encode('ascii'))(u'string')
+    s2 = intern('some python 2 string')
+    s3 = intern('some python 2 string')
+    assert s1 == s2
+    assert s1 is not s2
+    assert s2 is s3
+    assert not _Py2StrStruct.from_address(id(s1)).is_interned()
+    assert _Py2StrStruct.from_address(id(s2)).is_interned()
+    assert _Py2StrStruct.from_address(id(s3)).is_interned()
+
+
+@pytest.mark.skipif(sys.version_info[0] != 2,
+                    reason="Test relies on Python 2 str interning")
+def test_unsafe_mutable_bytes_with_python_2_interning():
+    buffer_holder = [intern(u"\x01\x02\x03".encode('ascii'))]
+    view = _memoryview_from_bytes(buffer_holder, 'B', False, (3,))
+    assert not view.readonly
+    assert len(buffer_holder) == 0
+
+    # Create a new interned buffer with the same original content
+    interned_buffer = intern(b"\x01\x02\x03")
+
+    # Mutate the view pointing the to the original buffer
+    view[:] = b'\x00\x00\x00'
+    assert interned_buffer == b'\x01\x02\x03'
+

--- a/tests/memoryview_test.py
+++ b/tests/memoryview_test.py
@@ -23,10 +23,10 @@ def test_safe_mutable_bytes():
     # Delete the local direct reference to the buffer
     del buffer
 
-    # There are no external reference to the bytes object in buffer_holder,
-    # the _memoryview_from_bytes function can safely reuse the memory
-    # allocated for the bytes object to expose it as a mutable buffer to back
-    # the memoryview when running CPython.
+    # There are no external reference to the bytes object in buffer_holder, the
+    # _memoryview_from_bytes function can safely reuse the memory allocated for
+    # the bytes object to expose it as a mutable buffer to back the memoryview
+    # when running CPython.
     if RUNNING_CPYTHON:
         assert _is_safe_to_mutate(buffer_holder)
     else:
@@ -88,7 +88,7 @@ def test_mutate_py3_single_element_bytes():
             assert not hasattr(view.obj, '_hidden_buffer_ref')
 
     # Single item bytes instances are not interned when using the bytes([i])
-    # constructor and this case, they can be mutated safely, they will not
+    # constructor and in this case, they can be mutated safely, they will not
     # impact the implicitly interned bytes singleton instances.
     for i in range(256):
         buffer_holder = [bytes([i])]

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -157,14 +157,5 @@ class PeakMemoryMonitor:
             return True
 
 
-class CountingByteSink(object):
-
-    def __init__(self):
-        self.written = 0
-
-    def write(self, data):
-        self.written += len(data)
-
-
 if __name__ == '__main__':
     pickle_echo()

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -113,7 +113,7 @@ def assert_run_python_script(source_code, timeout=5):
         os.unlink(source_file)
 
 
-def monitor_worker(pid, queue, stop_event, delay=0.05):
+def monitor_worker(pid, queue, stop_event, delay=0.010):
     import psutil
     p = psutil.Process(pid)
     peak = 0

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -3,9 +3,12 @@ import os
 import os.path as op
 import tempfile
 from subprocess import Popen, check_output, PIPE, STDOUT, CalledProcessError
+import gc
+import multiprocessing as mp
 
 from cloudpickle import dumps
 from pickle import loads
+import pytest
 
 try:
     from suprocess import TimeoutExpired
@@ -108,6 +111,59 @@ def assert_run_python_script(source_code, timeout=5):
                                % e.output.decode('utf-8'))
     finally:
         os.unlink(source_file)
+
+
+def monitor_worker(pid, queue, stop_event, delay=0.05):
+    import psutil
+    p = psutil.Process(pid)
+    peak = 0
+
+    def make_measurement(peak):
+        mem = p.memory_info().rss
+        if mem > peak:
+            peak = mem
+        return peak
+
+    # Make measurements every 'delay' seconds until we receive the stop event:
+    while not stop_event.wait(timeout=delay):
+        peak = make_measurement(peak)
+
+    # Make one last measurement in case memory has increased just before
+    # receiving the stop event:
+    peak = make_measurement(peak)
+    queue.put(peak)
+
+
+class PeakMemoryMonitor:
+
+    def __enter__(self):
+        psutil = pytest.importorskip("psutil")
+        pid = os.getpid()
+        gc.collect()
+        self.base_mem = psutil.Process(pid).memory_info().rss
+        self.queue = q = mp.Queue()
+        self.stop_event = e = mp.Event()
+        self.worker = mp.Process(target=monitor_worker, args=(pid, q, e))
+        self.worker.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        self.stop_event.set()
+        if exc_type is not None:
+            self.worker.terminate()
+            return False
+        else:
+            self.peak_mem = self.queue.get()
+            return True
+
+
+class CountingByteSink(object):
+
+    def __init__(self):
+        self.written = 0
+
+    def write(self, data):
+        self.written += len(data)
 
 
 if __name__ == '__main__':

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -154,6 +154,7 @@ class PeakMemoryMonitor:
             return False
         else:
             self.peak_mem = self.queue.get()
+            self.newly_allocated = self.peak_mem - self.base_mem
             return True
 
 


### PR DESCRIPTION
Here is a PR that backports some of the work done for large bytes in upstream CPython 3.7 or 3.8 in the following PR: https://github.com/python/cpython/pull/4353.

The goal is to make the `memoryview` support of cloudpickle benefit from it and implement nocopy semantics and later any nested numpy arrays datastructures (e.g. pandas dataframes, scipy sparse arrays, large scikit-learn RandomForestClassifier...).

In particular, this would make it possible for dask distributed to spill any large numpy-based datastructure to disk without making any temporary in-memory copy on workers that are close to their memory usage limit.

**Please do not merge this PR while the upstream CPython PR is still under review.**

- [x] prevent `_memoryview_from_bytes` to ever mutate single bytes interned  bytes instances,
- [x] add a battery of unittests to check edge cases with bytes mutability,
- [x] take the numpy serializer out of the test suite and make it available to users,
- [ ] fix pickling for numpy arrays with the object dtype,
- [x] wait for the final review of https://github.com/python/cpython/pull/4353,
- [ ] disable memoization of bytes when serializing a non-contiguous memoryview,
- [ ] refactor the new tests to make them less redundant.

/cc @pitrou @mrocklin.