### PR TITLE
Avoid iterating on sys.modules while it can be mutated

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -434,7 +434,10 @@ class CloudPickler(Pickler):
             if isinstance(x, types.ModuleType) and hasattr(x, '__package__') and x.__package__:
                 # check if the package has any currently loaded sub-imports
                 prefix = x.__name__ + '.'
-                for name, module in sys.modules.items():
+                # A concurrent thread could mutate sys.modules,
+                # make sure we iterate over a copy to avoid exceptions
+                modules = sys.modules.copy()
+                for name, module in modules.items():
                     # Older versions of pytest will add a "None" module to sys.modules.
                     if name is not None and name.startswith(prefix):
                         # check whether the function can address the sub-module


### PR DESCRIPTION
This was reported by one our users:
```
  File "/XXX/python3.5/site-packages/cloudpickle/cloudpickle.py", line 393, in _save_subimports
    for name, module in sys.modules.items():
RuntimeError: dictionary changed size during iteration
```

Most likely another thread was running concurrently and triggered
some import while cloudpickle was running this function.