### PR TITLE
[BRANCH-0.4.x] ApiModule can be vendored in the pytest package

### DIFF
--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -690,10 +690,10 @@ class CloudPickleTest(unittest.TestCase):
             s = py.builtin.set([1])
             return s.pop()
 
-        # some setup is required to allow pytest apimodules to be correctly serializable.
+        # some setup is required to allow pytest apimodules to be correctly
+        # serializable.
         from cloudpickle import CloudPickler
-        from py._apipkg import ApiModule
-        CloudPickler.dispatch[ApiModule] = CloudPickler.save_module
+        CloudPickler.dispatch[type(py.builtin)] = CloudPickler.save_module
         g = cloudpickle.loads(cloudpickle.dumps(f))
 
         result = g()


### PR DESCRIPTION
This PR backports https://github.com/cloudpipe/cloudpickle/pull/135 to fix the test failure.