### PR TITLE
[BRANCH-0.4.x] Fix #129: do not silence RuntimeError in dump() (#140)

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -262,6 +262,8 @@ class CloudPickler(Pickler):
             if 'recursion' in e.args[0]:
                 msg = """Could not pickle object as excessively deep recursion required."""
                 raise pickle.PicklingError(msg)
+            else:
+                raise
 
     def save_memoryview(self, obj):
         self.save(obj.tobytes())

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -49,6 +49,15 @@ from .testutils import subprocess_pickle_echo
 HAVE_WEAKSET = hasattr(weakref, 'WeakSet')
 
 
+class RaiserOnPickle(object):
+
+    def __init__(self, exc):
+        self.exc = exc
+
+    def __reduce__(self):
+        raise self.exc
+
+
 def pickle_depickle(obj):
     """Helper function to test whether object pickled with cloudpickle can be
     depickled with pickle
@@ -762,6 +771,12 @@ class CloudPickleTest(unittest.TestCase):
             b'\xff\xff\xff\xff}q\x0f\x87q\x10Rq\x11}q\x12N}q\x13U\x08__main__q'
             b'\x14NtR.')
         self.assertEquals(42, cloudpickle.loads(pickled)(42))
+
+    def test_pickle_reraise(self):
+        for exc_type in [Exception, ValueError, TypeError, RuntimeError]:
+            obj = RaiserOnPickle(exc_type("foo"))
+            with pytest.raises((exc_type, pickle.PicklingError)):
+                cloudpickle.dumps(obj)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR backports #140 to branch-0.4.x and fixes #129.