### PR TITLE
[BRANCH-0.4.x] BUG: Handle instancemethods of builtin types.

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -331,7 +331,13 @@ class CloudPickler(Pickler):
         Determines what kind of function obj is (e.g. lambda, defined at
         interactive prompt, etc) and handles the pickling appropriately.
         """
-        if obj in _BUILTIN_TYPE_CONSTRUCTORS:
+        try:
+            should_special_case = obj in _BUILTIN_TYPE_CONSTRUCTORS
+        except TypeError:
+            # Methods of builtin types aren't hashable in python 2.
+            should_special_case = False
+
+        if should_special_case:
             # We keep a special-cased cache of built-in type constructors at
             # global scope, because these functions are structured very
             # differently in different python versions and implementations (for

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -835,6 +835,12 @@ class CloudPickleTest(unittest.TestCase):
             with pytest.raises((exc_type, pickle.PicklingError)):
                 cloudpickle.dumps(obj)
 
+    def test_unhashable_function(self):
+        d = {'a': 1}
+        depickled_method = pickle_depickle(d.get)
+        self.assertEquals(depickled_method('a'), 1)
+        self.assertEquals(depickled_method('b'), None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR backports #145 to branch-0.4.x and fixes #144.