### PR TITLE
BUG: itertools objects are actually picklable

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -284,16 +284,6 @@ class CloudPickler(Pickler):
 
         dispatch[buffer] = save_buffer
 
-    def save_unsupported(self, obj):
-        raise pickle.PicklingError("Cannot pickle objects of type %s" % type(obj))
-
-    dispatch[types.GeneratorType] = save_unsupported
-
-    # itertools objects do not pickle!
-    for v in itertools.__dict__.values():
-        if type(v) is type:
-            dispatch[v] = save_unsupported
-
     def save_module(self, obj):
         """
         Save a module as an import

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -347,15 +347,6 @@ class CloudPickleTest(unittest.TestCase):
         else:  # skip if scipy is not available
             pass
 
-    def test_save_unsupported(self):
-        sio = StringIO()
-        pickler = cloudpickle.CloudPickler(sio, 2)
-
-        with pytest.raises(pickle.PicklingError) as excinfo:
-            pickler.save_unsupported("test")
-
-        assert "Cannot pickle objects of type" in str(excinfo.value)
-
     def test_loads_namespace(self):
         obj = 1, 2, 3, 4
         returned_obj = cloudpickle.loads(cloudpickle.dumps(obj))
@@ -882,6 +873,20 @@ class CloudPickleTest(unittest.TestCase):
         depickled_method = pickle_depickle(d.get)
         self.assertEquals(depickled_method('a'), 1)
         self.assertEquals(depickled_method('b'), None)
+
+    def test_itertools_count(self):
+        counter = itertools.count(1, step=2)
+
+        # advance the counter a bit
+        next(counter)
+        next(counter)
+
+        new_counter = pickle_depickle(counter, protocol=self.protocol)
+
+        self.assertTrue(counter is not new_counter)
+
+        for _ in range(10):
+            self.assertEqual(next(counter), next(new_counter))
 
 
 class Protocol2CloudPickleTest(CloudPickleTest):


### PR DESCRIPTION
someone pointed this out to me in a cloudpickle-generators PR. I looked into the CPython source and saw that itertools types are actually picklable. I am not sure why we have `save_unsupported` at all. If we don't know what to do with something, we should just fall back to pickle, which fails with a nice error. For example:

```python
In [2]: def f():
   ...:     yield
   ...:     

In [3]: cp.dumps(f())
   ...

TypeError: can't pickle generator objects
```

The added test is a regression test, even though the `__reduce__` implementation is in Python itself.