### PR TITLE
'buffer' and 'file' are undefined names in Python 3

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -282,7 +282,7 @@ class CloudPickler(Pickler):
         def save_buffer(self, obj):
             self.save(str(obj))
 
-        dispatch[buffer] = save_buffer
+        dispatch[buffer] = save_buffer  # noqa: F821 'buffer' was removed in Python 3
 
     def save_module(self, obj):
         """
@@ -815,10 +815,10 @@ class CloudPickler(Pickler):
     def save_not_implemented(self, obj):
         self.save_reduce(_gen_not_implemented, ())
 
-    if PY3:
-        dispatch[io.TextIOWrapper] = save_file
-    else:
+    try:               # Python 2
         dispatch[file] = save_file
+    except NameError:  # Python 3
+        dispatch[io.TextIOWrapper] = save_file
 
     dispatch[type(Ellipsis)] = save_ellipsis
     dispatch[type(NotImplemented)] = save_not_implemented


### PR DESCRIPTION
__cloudpickle.py__ refers to:
* __buffer__ which was removed from Python 3 in favor of [memoryview](https://docs.python.org/2/c-api/buffer.html)
* __file__ which was removed from Python 3 in favor of __io.TextIOWrapper__

The try/except approach for __file__ follows the Python porting best practice [use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).