### PR TITLE
[BRANCH-0.4.x] Use Flake8 to find Python syntax errors or undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ install:
   - pip install -r dev-requirements.txt
   - pip install tornado
   - pip list
+before_script:
+  - pip install flake8
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
   - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then source activate testenv; fi
   - PYTHONPATH='.:tests' py.test -r s --cov-config .coveragerc --cov=cloudpickle

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 # Dependencies for running the tests with py.test
+flake8
 pytest
 pytest-cov
 mock


### PR DESCRIPTION
This PR backports https://github.com/cloudpipe/cloudpickle/pull/162.