### PR TITLE
TST add Python 3.7 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   - "pypy"
 
 # This disables sudo, but makes builds start much faster

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: python
-sudo: false
+dist: xenial
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, pypy, pypy3
+envlist = py27, py34, py35, py36, py37, pypy, pypy3
 
 [testenv]
 deps = -rdev-requirements.txt


### PR DESCRIPTION
This should fail on travis and give the full tracebacks for reproducing #180.

I don't have time to investigate now but if you do feel free to push directly in my PR.