### PR TITLE
FIX pickling for ABC in python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 language: python
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
-  - "3.7-dev"
-  - "pypy"
+
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      sudo: required
+      dist: xenial
+    - python: "pypy"
+
 
 # This disables sudo, but makes builds start much faster
 # See http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
-sudo: false
 before_install: bash ./ci/before_install.sh
 install:
   - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then source activate testenv; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
-dist: xenial
 python:
   - "2.7"
   - "3.5"
   - "3.6"
-  - "3.7"
+  - "3.7-dev"
   - "pypy"
 
 # This disables sudo, but makes builds start much faster

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
-sudo: false
+dist: xenial
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   - "pypy"
 
 # This disables sudo, but makes builds start much faster

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -3,6 +3,12 @@
 # if python version is not PyPY, then install miniconda
 if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]
 then
+    export PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
+    if [[ $TRAVIS_PYTHON_VERSION == "3.7-dev" ]]
+    then
+        export PYTHON_VERSION="3.7"
+    fi
+
     # Escape standard Travis virtualenv
     deactivate
     # See: http://conda.pydata.org/docs/travis.html
@@ -13,5 +19,5 @@ then
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
     conda info -a
-    conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION numpy scipy pip
+    conda create -q -n testenv python=$PYTHON_VERSION numpy scipy pip
 fi

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # if python version is not PyPY, then install miniconda
-if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* && $TRAVIS_PYTHON_VERSION != "3.7-dev" ]]
+if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* && $TRAVIS_PYTHON_VERSION != "3.7" ]]
 then
 
     # Escape standard Travis virtualenv

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
 # if python version is not PyPY, then install miniconda
-if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]
+if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* && $TRAVIS_PYTHON_VERSION != "3.7-dev" ]]
 then
-    export PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
-    if [[ $TRAVIS_PYTHON_VERSION == "3.7-dev" ]]
-    then
-        export PYTHON_VERSION="3.7"
-    fi
 
     # Escape standard Travis virtualenv
     deactivate
@@ -19,5 +14,5 @@ then
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
     conda info -a
-    conda create -q -n testenv python=$PYTHON_VERSION numpy scipy pip
+    conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION numpy scipy pip
 fi

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -460,6 +460,14 @@ class CloudPickler(Pickler):
         clsdict = dict(obj.__dict__)  # copy dict proxy to a dict
         clsdict.pop('__weakref__', None)
 
+        # For ABCMeta in python3.7, remove _abc_impl as it is not picklable.
+        # This is a fix which breaks the cache but this only makes the first
+        # calls to issubclass slower.
+        if "_abc_impl" in clsdict:
+            import abc
+            (registry, *_) = abc._get_dump(obj)
+            clsdict["_abc_impl"] = [wr() for wr in registry]
+
         # On PyPy, __doc__ is a readonly attribute, so we need to include it in
         # the initial skeleton class.  This is safe because we know that the
         # doc can't participate in a cycle with the original class.
@@ -1082,8 +1090,16 @@ def _rehydrate_skeleton_class(skeleton_class, class_dict):
 
     See CloudPickler.save_dynamic_class for more info.
     """
+    registry = None
     for attrname, attr in class_dict.items():
-        setattr(skeleton_class, attrname, attr)
+        if attrname == "_abc_impl":
+            registry = attr
+        else:
+            setattr(skeleton_class, attrname, attr)
+    if registry is not None:
+        for subclass in registry:
+            skeleton_class.register(subclass)
+
     return skeleton_class
 
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -465,7 +465,7 @@ class CloudPickler(Pickler):
         # calls to issubclass slower.
         if "_abc_impl" in clsdict:
             import abc
-            (registry, *_) = abc._get_dump(obj)
+            (registry, _, _, _) = abc._get_dump(obj)
             clsdict["_abc_impl"] = [wr() for wr in registry]
 
         # On PyPy, __doc__ is a readonly attribute, so we need to include it in

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -460,13 +460,14 @@ class CloudPickler(Pickler):
         clsdict = dict(obj.__dict__)  # copy dict proxy to a dict
         clsdict.pop('__weakref__', None)
 
-        # For ABCMeta in python3.7, remove _abc_impl as it is not picklable.
+        # For ABCMeta in python3.7+, remove _abc_impl as it is not picklable.
         # This is a fix which breaks the cache but this only makes the first
         # calls to issubclass slower.
         if "_abc_impl" in clsdict:
             import abc
             (registry, _, _, _) = abc._get_dump(obj)
-            clsdict["_abc_impl"] = [wr() for wr in registry]
+            clsdict["_abc_impl"] = [subclass_weakref()
+                                    for subclass_weakref in registry]
 
         # On PyPy, __doc__ is a readonly attribute, so we need to include it in
         # the initial skeleton class.  This is safe because we know that the

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -655,6 +655,8 @@ class CloudPickleTest(unittest.TestCase):
             def foo(self):
                 return 'it works!'
 
+        # This class is local so we can safely register tuple in it to verify
+        # the unpickled class also register tuple.
         AbstractClass.register(tuple)
 
         depickled_base = pickle_depickle(AbstractClass, protocol=self.protocol)

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -655,10 +655,15 @@ class CloudPickleTest(unittest.TestCase):
             def foo(self):
                 return 'it works!'
 
+        AbstractClass.register(tuple)
+
         depickled_base = pickle_depickle(AbstractClass, protocol=self.protocol)
         depickled_class = pickle_depickle(ConcreteClass,
                                           protocol=self.protocol)
         depickled_instance = pickle_depickle(ConcreteClass())
+
+        assert issubclass(tuple, AbstractClass)
+        assert issubclass(tuple, depickled_base)
 
         self.assertEqual(depickled_class().foo(), 'it works!')
         self.assertEqual(depickled_instance.foo(), 'it works!')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, pypy, pypy3
+envlist = py27, py34, py35, py36, py37, pypy, pypy3
 
 [testenv]
 deps = -rdev-requirements.txt


### PR DESCRIPTION
Fix #180 

The issue was that the `abc` module have been entirely re-written in C. (python/cpython#5273)

The `register` mechanism is not accessible anymore. The proposed implementation simply pickle the registered classes using `abc._get_dump` and then re-register them. This does not conserve the `cache` but this does not seem to be an issue (it is only a matter of performance for the first call to `issubclass`).