### PR TITLE
Remove annotations for python3.6 and below

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ master
 - Ensure that unpickling a function defined in a dynamic module several times
   sequentially does not reset the values of global variables.
   ([issue #187](https://github.com/cloudpipe/cloudpickle/issues/205))
+- Restrict the ability to pickle annotations to python3.7+ ([issue #193](
+  https://github.com/cloudpipe/cloudpickle/issues/193) and [issue #196](https://github.com/cloudpipe/cloudpickle/issues/196))
 
 
 0.5.6

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -566,7 +566,7 @@ class CloudPickler(Pickler):
             'name': func.__name__,
             'doc': func.__doc__,
         }
-        if hasattr(func, '__annotations__'):
+        if hasattr(func, '__annotations__') and sys.version_info >= (3, 7):
             state['annotations'] = func.__annotations__
         if hasattr(func, '__qualname__'):
             state['qualname'] = func.__qualname__

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -969,7 +969,9 @@ class CloudPickleTest(unittest.TestCase):
 
         self.assertEqual(f2.__doc__, f.__doc__)
 
-    @unittest.skipIf(sys.version_info[0] < 3, "This syntax won't work on py2.")
+    @unittest.skipIf(sys.version_info < (3, 7),
+                     """This syntax won't work on py2 and pickling annotations
+                     isn't supported for py36 and below.""")
     def test_wraps_preserves_function_annotations(self):
         from functools import wraps
 


### PR DESCRIPTION
Closes #193 and closes #196 with a heavy hand, by removing the ability to include `__annotations__` in versions of python < 3.7.  

It seemed the ability to pickle arbitrary `typing` classes was [a deep rabbit hole](https://github.com/python/typing/issues/511#issuecomment-350025988) external to `cloudpickle`, and AFAIK the alternative would be some sort of check / try / except on annotations that would lead to inconsistent pickling of `__annotations__`.