### PR TITLE
MNT Add a non regression test for base globals

### DIFF
--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -510,15 +510,18 @@ class CloudPickleTest(unittest.TestCase):
                 os.unlink(child_process_module_file)
 
     def test_correct_globals_import(self):
-        def unrelated_function(x):
-            return math.exp(x)
+        import math
 
         def my_small_function(x, y):
             return x+y
 
         b = cloudpickle.dumps(my_small_function)
+
+        # Cloudpickle will use the current module's name for base_globals.
+        # Separately, global variables used by my_small_function will be
+        # pickled in f_globals. So at no point should 'math' appear in the
+        # pickled object, since it is not used by my_small_function explicitly
         assert b'my_small_function' in b
-        assert b'unrelated_function' not in b
         assert b'math' not in b
 
     def test_find_module(self):

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -513,7 +513,10 @@ class CloudPickleTest(unittest.TestCase):
         import math
 
         def my_small_function(x, y):
-            return x+y
+            def nested_function():
+                pass
+
+            return x + y
 
         b = cloudpickle.dumps(my_small_function)
 
@@ -523,6 +526,10 @@ class CloudPickleTest(unittest.TestCase):
         # pickled object, since it is not used by my_small_function explicitly
         assert b'my_small_function' in b
         assert b'math' not in b
+
+        # nested_function is a local variable defined inside my_small_function,
+        # so its name should appear in the pickled object
+        assert b'nested_function' in b
 
     def test_find_module(self):
         import pickle  # ensure this test is decoupled from global imports

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -8,6 +8,7 @@ import imp
 from io import BytesIO
 import itertools
 import logging
+import math
 from operator import itemgetter, attrgetter
 import pickle
 import platform
@@ -507,6 +508,18 @@ class CloudPickleTest(unittest.TestCase):
                 os.unlink(parent_process_module_file)
             if os.path.exists(child_process_module_file):
                 os.unlink(child_process_module_file)
+
+    def test_correct_globals_import(self):
+        def unrelated_function(a):
+            return math.exp(a)
+
+        def my_small_function(a):
+            return a+b
+
+        b = cloudpickle.dumps(my_small_function)
+        assert b'my_small_function' in b
+        assert b'unrelated_function' not in b
+        assert b'math' not in b
 
     def test_find_module(self):
         import pickle  # ensure this test is decoupled from global imports

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -521,10 +521,10 @@ class CloudPickleTest(unittest.TestCase):
 
         b = cloudpickle.dumps(my_small_function)
 
-        # Make sure that the pickle byte strings only includes the definition
+        # Make sure that the pickle byte string only includes the definition
         # of my_small_function and its dependency nested_function while
-        # extra function and modules such as unwanted_function and the math
-        # modules are not included so as to keep the pickle payload as
+        # extra functions and modules such as unwanted_function and the math
+        # module are not included so as to keep the pickle payload as
         # lightweight as possible.
 
         assert b'my_small_function' in b

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -510,11 +510,11 @@ class CloudPickleTest(unittest.TestCase):
                 os.unlink(child_process_module_file)
 
     def test_correct_globals_import(self):
-        def unrelated_function(a):
-            return math.exp(a)
+        def unrelated_function(x):
+            return math.exp(x)
 
-        def my_small_function(a):
-            return a+b
+        def my_small_function(x, y):
+            return x+y
 
         b = cloudpickle.dumps(my_small_function)
         assert b'my_small_function' in b

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -510,13 +510,14 @@ class CloudPickleTest(unittest.TestCase):
                 os.unlink(child_process_module_file)
 
     def test_correct_globals_import(self):
-        import math
-
         def my_small_function(x, y):
             def nested_function():
                 pass
 
             return x + y
+
+        def unwanted_function(x):
+            return math.exp(x)
 
         b = cloudpickle.dumps(my_small_function)
 
@@ -525,11 +526,14 @@ class CloudPickleTest(unittest.TestCase):
         # pickled in f_globals. So at no point should 'math' appear in the
         # pickled object, since it is not used by my_small_function explicitly
         assert b'my_small_function' in b
-        assert b'math' not in b
 
         # nested_function is a local variable defined inside my_small_function,
         # so its name should appear in the pickled object
         assert b'nested_function' in b
+
+        # unwanted_function should not appear in the pickled nested_function
+        # object. We check this as a non-regression test.
+        assert b'unwanted_function' not in b
 
     def test_find_module(self):
         import pickle  # ensure this test is decoupled from global imports


### PR DESCRIPTION
Fixes #203, by adding a test that ensures that no unnecessary global variable of an pickled function is imported during depickling. 
Inspired from [this dask PR](https://github.com/dask/dask/pull/3984), but
*  I replaced `numpy` with `math` to use a module from the standard library
* I removed `unrelated_function` as it is not part of  `my_small_function.__globals__` because those functions are themselves defined in a local scope.

ping @ogrisel @tomMoral 