### PR TITLE
Fix module locals has no builtins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+0.6.1
+=====
+
+- Fix regression in 0.6.0 which breaks the pickling of local function defined    in a module, making it impossible to access builtins functions.
+  ([issue #211](https://github.com/cloudpipe/cloudpickle/issues/211))
+
+
 0.6.0
 =====
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -1105,6 +1105,9 @@ def _make_skel_func(code, cell_count, base_globals=None):
     elif isinstance(base_globals, str):
         base_globals_name = base_globals
         try:
+            # First try to reuse the globals from the module containing the
+            # function. If it is not possible to retrieve it, fallback to an
+            # empty dictionary.
             base_globals = vars(importlib.import_module(base_globals))
         except ImportError:
             base_globals = _dynamic_modules_globals.get(

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -42,19 +42,20 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 from __future__ import print_function
 
-import dis
-from functools import partial
 import io
-import itertools
-import logging
+import dis
+import sys
+import types
 import opcode
-import operator
 import pickle
 import struct
-import sys
-import traceback
-import types
+import logging
 import weakref
+import operator
+import importlib
+import itertools
+import traceback
+from functools import partial
 
 
 # cloudpickle is meant for inter process communication: we expect all
@@ -1103,11 +1104,9 @@ def _make_skel_func(code, cell_count, base_globals=None):
         base_globals = {}
     elif isinstance(base_globals, str):
         base_globals_name = base_globals
-        if sys.modules.get(base_globals, None) is not None:
-            # This checks if we can import the previous environment the object
-            # lived in
-            base_globals = vars(sys.modules[base_globals])
-        else:
+        try:
+            base_globals = vars(importlib.import_module(base_globals))
+        except ImportError:
             base_globals = _dynamic_modules_globals.get(
                     base_globals_name, None)
             if base_globals is None:

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -17,6 +17,19 @@ except ImportError:
     timeout_supported = False
 
 
+TEST_GLOBALS = "a test value"
+
+
+def make_local_function():
+    def g(x):
+        # this function checks that the globals are correctly handled and that
+        # the builtins are available
+        assert TEST_GLOBALS == "a test value"
+        return sum(range(10))
+
+    return g
+
+
 def subprocess_pickle_echo(input_data, protocol=None):
     """Echo function with a child Python process
 


### PR DESCRIPTION
Fixes #211 

This PR fix the way we detect that a module is importable for local functions.
Note that this not completly fixes the problem in #211 as the issue still appears for dynamic modules __eg__ if you change `tests/cloudpickle_test.py` from line 419 to

```python

    def test_dynamic_module(self):
        mod = types.ModuleType('mod')
        code = '''
        x = 1
        def f(y):
            range(10)
            return x + y

        class Foo:
            def method(self, x):
                return f(x)
        '''
        exec(textwrap.dedent(code), mod.__dict__)
        mod2 = pickle_depickle(mod, protocol=self.protocol)
        self.assertEqual(mod.x, mod2.x)
        self.assertEqual(mod.f(5), mod2.f(5))
        self.assertEqual(mod.Foo().method(5), mod2.Foo().method(5))

        if platform.python_implementation() != 'PyPy':
            # XXX: this fails with excessive recursion on PyPy.
            mod3 = subprocess_pickle_echo(mod, protocol=self.protocol)
            self.assertEqual(mod.x, mod3.x)
            self.assertEqual(mod.f(5), mod3.f(5))
            self.assertEqual(mod.Foo().method(5), mod3.Foo().method(5))

        # Test dynamic modules when imported back are singletons
        mod1, mod2 = pickle_depickle([mod, mod])
        self.assertEqual(id(mod1), id(mod2))
```

then the output of the test is

```python
_______________________________________________________________________________________ CloudPickleTest.test_dynamic_module _______________________________________________________________________________________

self = <tests.cloudpickle_test.CloudPickleTest testMethod=test_dynamic_module>

    def test_dynamic_module(self):
        mod = types.ModuleType('mod')
        code = '''
            x = 1
            def f(y):
                range(10)
                return x + y
    
            class Foo:
                def method(self, x):
                    return f(x)
            '''
        exec(textwrap.dedent(code), mod.__dict__)
        mod2 = pickle_depickle(mod, protocol=self.protocol)
        self.assertEqual(mod.x, mod2.x)
        self.assertEqual(mod.f(5), mod2.f(5))
        self.assertEqual(mod.Foo().method(5), mod2.Foo().method(5))
    
        if platform.python_implementation() != 'PyPy':
            # XXX: this fails with excessive recursion on PyPy.
            mod3 = subprocess_pickle_echo(mod, protocol=self.protocol)
            self.assertEqual(mod.x, mod3.x)
            self.assertEqual(mod.f(5), mod3.f(5))
            self.assertEqual(mod.Foo().method(5), mod3.Foo().method(5))
    
        # Test dynamic modules when imported back are singletons
>       mod1, mod2 = pickle_depickle([mod, mod])

code       = '\n        x = 1\n        def f(y):\n            range(10)\n            return x + y\n\n        class Foo:\n            def method(self, x):\n                return f(x)\n        '
mod        = <module 'mod'>
mod2       = <module 'mod'>
mod3       = <module 'mod'>
self       = <tests.cloudpickle_test.CloudPickleTest testMethod=test_dynamic_module>

tests/cloudpickle_test.py:445: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/cloudpickle_test.py:69: in pickle_depickle
    return pickle.loads(cloudpickle.dumps(obj, protocol=protocol))
cloudpickle/cloudpickle.py:931: in dumps
    cp.dump(obj)
cloudpickle/cloudpickle.py:284: in dump
    return Pickler.dump(self, obj)
/usr/lib/python3.4/pickle.py:412: in dump
    self.save(obj)
/usr/lib/python3.4/pickle.py:479: in save
    f(self, obj) # Call unbound method with explicit self
/usr/lib/python3.4/pickle.py:774: in save_list
    self._batch_appends(obj)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <cloudpickle.cloudpickle.CloudPickler object at 0x7f63bc9d3550>, items = [<module 'mod'>, <module 'mod'>]

    def _batch_appends(self, items):
        # Helper to batch up APPENDS sequences
        save = self.save
        write = self.write
    
        if not self.bin:
            for x in items:
                save(x)
                write(APPEND)
            return
    
        it = iter(items)
        while True:
>           tmp = list(islice(it, self._BATCHSIZE))
E           KeyError: 'range'

it         = <list_iterator object at 0x7f63bc9d3c50>
items      = [<module 'mod'>, <module 'mod'>]
save       = <bound method CloudPickler.save of <cloudpickle.cloudpickle.CloudPickler object at 0x7f63bc9d3550>>
self       = <cloudpickle.cloudpickle.CloudPickler object at 0x7f63bc9d3550>
write      = <bound method _Framer.write of <pickle._Framer object at 0x7f63bc9d3e10>>

/usr/lib/python3.4/pickle.py:793: KeyError
```

But I don't think it is possible to fix that as it probably has to do with internal dealing of python for creating a `FunctionType` object .