### PR TITLE
ENH Add a switch to override existing global variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+0.7.0
+=====
+
+- Add a switch in `cloudpickle.dump` speficying if variables present in the
+  written pickle string should override colluding values present in their new
+  namespace at unpickling time.
+  ([issue #214](https://github.com/cloudpipe/cloudpickle/issues/214))
+
+
 0.6.1
 =====
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -78,6 +78,7 @@ class CloudPicklerTest(unittest.TestCase):
 class CloudPickleTest(unittest.TestCase):
 
     protocol = cloudpickle.DEFAULT_PROTOCOL
+    override_existing_globals = False
 
     def test_itemgetter(self):
         d = range(10)
@@ -1075,7 +1076,9 @@ class CloudPickleTest(unittest.TestCase):
 
         cloned_f0 = {clone_func}(f0, protocol={protocol})
         cloned_f1 = {clone_func}(f1, protocol={protocol})
-        pickled_f1 = dumps(f1, protocol={protocol})
+        pickled_f1 = dumps(
+            f1, protocol={protocol},
+            override_existing_globals={override_existing_globals})
 
         # Change the value of the global variable
         cloned_f0()
@@ -1084,13 +1087,19 @@ class CloudPickleTest(unittest.TestCase):
         result_f1 = cloned_f1()
         assert result_f1 == "changed_by_f0", result_f1
 
-        # Ensure that unpickling the global variable does not change its value
+        # Ensure that unpickling the global variable overrides (resp. does not
+        # change) the global variable if override_existing_globals was True
+        # (resp. False) at pickling time
         result_pickled_f1 = loads(pickled_f1)()
-        assert result_pickled_f1 == "changed_by_f0", result_pickled_f1
+        if {override_existing_globals}:
+            assert result_pickled_f1 == "default_value", result_pickled_f1
+        else:
+            assert result_pickled_f1 == "changed_by_f0", result_pickled_f1
         """
         for clone_func in ['local_clone', 'subprocess_pickle_echo']:
-            code = code_template.format(protocol=self.protocol,
-                                        clone_func=clone_func)
+            code = code_template.format(
+                protocol=self.protocol, clone_func=clone_func,
+                override_existing_globals=self.override_existing_globals)
             assert_run_python_script(textwrap.dedent(code))
 
     def test_closure_interacting_with_a_global_variable(self):
@@ -1106,10 +1115,16 @@ class CloudPickleTest(unittest.TestCase):
                 return _TEST_GLOBAL_VARIABLE
 
             cloned_f0 = cloudpickle.loads(cloudpickle.dumps(
-                f0, protocol=self.protocol))
+                f0, protocol=self.protocol,
+                override_existing_globals=self.override_existing_globals))
+
             cloned_f1 = cloudpickle.loads(cloudpickle.dumps(
-                f1, protocol=self.protocol))
-            pickled_f1 = cloudpickle.dumps(f1, protocol=self.protocol)
+                f1, protocol=self.protocol,
+                override_existing_globals=self.override_existing_globals))
+
+            pickled_f1 = cloudpickle.dumps(
+                f1, protocol=self.protocol,
+                override_existing_globals=self.override_existing_globals)
 
             # Change the value of the global variable
             cloned_f0()
@@ -1120,10 +1135,14 @@ class CloudPickleTest(unittest.TestCase):
             assert result_cloned_f1 == "changed_by_f0", result_cloned_f1
             assert f1() == result_cloned_f1
 
-            # Ensure that unpickling the global variable does not change its
-            # value
+            # Ensure that unpickling the global variable overrides (resp.
+            # does not change) its value if override_existing_globals was True
+            # (resp False) at pickling time
             result_pickled_f1 = cloudpickle.loads(pickled_f1)()
-            assert result_pickled_f1 == "changed_by_f0", result_pickled_f1
+            if self.override_existing_globals:
+                assert result_pickled_f1 == "default_value", result_pickled_f1
+            else:
+                assert result_pickled_f1 == "changed_by_f0", result_pickled_f1
         finally:
             _TEST_GLOBAL_VARIABLE = orig_value
 
@@ -1160,7 +1179,9 @@ class CloudPickleTest(unittest.TestCase):
             # GLOBAL_STATE's value at the time of pickling.
 
             with open('function_with_initial_globals.pkl', 'wb') as f:
-                cloudpickle.dump(mod.func_defined_in_dynamic_module, f)
+                cloudpickle.dump(
+                    mod.func_defined_in_dynamic_module, f,
+                    override_existing_globals=self.override_existing_globals)
 
             # Change the mod's global variable
             mod.GLOBAL_STATE = 'changed value'
@@ -1169,8 +1190,9 @@ class CloudPickleTest(unittest.TestCase):
             # returns the updated value. Let's pickle it again.
             assert mod.func_defined_in_dynamic_module() == 'changed value'
             with open('function_with_modified_globals.pkl', 'wb') as f:
-                cloudpickle.dump(mod.func_defined_in_dynamic_module, f,
-                                 protocol=self.protocol)
+                cloudpickle.dump(
+                    mod.func_defined_in_dynamic_module, f,
+                    override_existing_globals=self.override_existing_globals)
 
             child_process_code = """
                 import pickle
@@ -1189,20 +1211,34 @@ class CloudPickleTest(unittest.TestCase):
                 with open('function_with_modified_globals.pkl','rb') as f:
                     func_with_modified_globals = pickle.load(f)
 
-                # assert the this unpickling did not modify the value of
-                # the local
-                assert func_with_modified_globals() == 'initial value'
+                # Verify that loading the function overrides (resp. does not
+                # change) the global variable GLOBAL_STATE of mod, if
+                # override_existing_globals was True (resp. False) at pickling
+                # time
+
+                if {override_existing_globals}:
+                    assert func_with_modified_globals() == 'changed value'
+                else:
+                    assert func_with_modified_globals() == 'initial value'
 
                 # Update the value from the child process and check that
-                # unpickling again does not reset our change.
+                # unpickling reset (resp. does not reset) our change if
+                # override_existing_globals was True (resp. False) at pickling
+                # time
                 assert func_with_initial_globals('new value') == 'new value'
                 assert func_with_modified_globals() == 'new value'
 
                 with open('function_with_initial_globals.pkl','rb') as f:
                     func_with_initial_globals = pickle.load(f)
-                assert func_with_initial_globals() == 'new value'
-                assert func_with_modified_globals() == 'new value'
-            """
+
+                if {override_existing_globals}:
+                    assert func_with_initial_globals() == 'initial value'
+                    assert func_with_modified_globals() == 'initial value'
+                else:
+                    assert func_with_initial_globals() == 'new value'
+                    assert func_with_modified_globals() == 'new value'
+
+            """.format(override_existing_globals=self.override_existing_globals)
             assert_run_python_script(textwrap.dedent(child_process_code))
 
         finally:
@@ -1314,6 +1350,7 @@ class CloudPickleTest(unittest.TestCase):
 class Protocol2CloudPickleTest(CloudPickleTest):
 
     protocol = 2
+    override_existing_globals = True
 
 
 if __name__ == '__main__':

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1151,7 +1151,7 @@ class CloudPickleTest(unittest.TestCase):
     def test_function_from_dynamic_module_with_globals_modifications(self):
         # This test verifies that the global variable state of a function
         # defined in a dynamic module in a child process are not reset by
-        # subsequent uplickling.
+        # subsequent unpickling.
 
         for override_existing_globals in [True, False]:
             try:
@@ -1176,9 +1176,10 @@ class CloudPickleTest(unittest.TestCase):
                 # functions. Those unpickle functions should share the same
                 # global variables in the child process: Once the first
                 # function gets unpickled, mod is created and tracked in the
-                # child environment. This is state is preserved when unpickling
-                # the second function whatever the global variable
-                # GLOBAL_STATE's value at the time of pickling.
+                # child environment. If override_globals is False, then the
+                # module state is preserved when unpickling the second function
+                # whatever the global variable GLOBAL_STATE's value at the time
+                # of pickling.
 
                 with open('function_with_initial_globals.pkl', 'wb') as f:
                     cloudpickle.dump(
@@ -1224,7 +1225,7 @@ class CloudPickleTest(unittest.TestCase):
                         assert func_with_modified_globals() == 'initial value'
 
                     # Update the value from the child process and check that
-                    # unpickling reset (resp. does not reset) our change if
+                    # unpickling resets (resp. does not reset) our change if
                     # override_existing_globals was True (resp. False) at
                     # pickling time
                     assert (


### PR DESCRIPTION
Following #214.
This PR implements a switch called `override_existing_globals`, available from `CloudPickler.__init__`, `cloudpickle.dumps` and `cloudpickle.dump`.

* If set to `True`, the globals from a function originally created in the  `__main__` module, dynamic modules or in a nested scope override the globals of the function's module at unpickling time.
* If set to `False`, the existing variables in the function's module overrides the globals of those functions at unpickling time.