### PR TITLE
CLN remove `hasattr` check before accessing __module__

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -645,7 +645,7 @@ class CloudPickler(Pickler):
             # vars(func.__module__) for base_globals. This is necessary to
             # share the global variables across multiple pickled functions from
             # this module.
-            if hasattr(func, '__module__') and func.__module__ is not None:
+            if func.__module__ is not None:
                 base_globals = func.__module__
             else:
                 base_globals = {}


### PR DESCRIPTION
fixes #217 
If anyone know a case where this `hasattr` check is useful, let me know.