### PR TITLE
DOC fix doc for _make_cell_template_code

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -112,7 +112,7 @@ def _make_cell_set_template_code():
 
            return _stub
 
-        _cell_set_template_code = f()
+        _cell_set_template_code = f().__code__
 
     This function is _only_ a LOAD_FAST(arg); STORE_DEREF, but that is
     invalid syntax on Python 2. If we use this function we also don't need


### PR DESCRIPTION
Small fix for the documentation of _make_cell_template_code.
By the way, thanks a lot whoever took the time to write this explanation. This part of the code is a little bit cryptic, and the doc helped write a clean python 3 only version of this. 