### PR TITLE
ENH pickle classes and objects with __slots__

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+0.7.0
+=====
+
+- Correctly serialize dynamically defined classes that have a `__slots__`
+  attribute.
+  ([issue #225](https://github.com/cloudpipe/cloudpickle/issues/225))
+
+
 0.6.1
 =====
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -55,6 +55,7 @@ import operator
 import importlib
 import itertools
 import traceback
+import six
 from functools import partial
 
 
@@ -499,6 +500,17 @@ class CloudPickler(Pickler):
         # the initial skeleton class.  This is safe because we know that the
         # doc can't participate in a cycle with the original class.
         type_kwargs = {'__doc__': clsdict.pop('__doc__', None)}
+
+        if hasattr(obj, "__slots__"):
+            type_kwargs['__slots__'] = obj.__slots__
+            # pickle string length optimization: member descriptors of obj are
+            # created automatically from obj's __slots__ attribute, no need to
+            # save them in obj's state
+            if isinstance(obj.__slots__, six.string_types):
+                clsdict.pop(obj.__slots__)
+            else:
+                for k in obj.__slots__:
+                    clsdict.pop(k, None)
 
         # If type overrides __dict__ as a property, include it in the type kwargs.
         # In Python 2, we can't set this attribute after construction.

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1310,6 +1310,23 @@ class CloudPickleTest(unittest.TestCase):
 
         self.assertEqual(f2.__annotations__, f.__annotations__)
 
+    def test_instance_with_slots(self):
+        for slots in [["registered_attribute"], "registered_attribute"]:
+            class ClassWithSlots(object):
+                __slots__ = slots
+
+                def __init__(self):
+                    self.registered_attribute = 42
+
+            initial_obj = ClassWithSlots()
+            depickled_obj = pickle_depickle(
+                initial_obj, protocol=self.protocol)
+
+            for obj in [initial_obj, depickled_obj]:
+                self.assertEqual(obj.registered_attribute, 42)
+                with pytest.raises(AttributeError):
+                    obj.non_registered_attribute = 1
+
 
 class Protocol2CloudPickleTest(CloudPickleTest):
 


### PR DESCRIPTION
closes #225 

Note that this this implementation will fail if the class `__slots__` attribute is modified after the class creation. 
Choosing to handle this case would lead to complex and tedious code, and I am not even sure we can guess correctly the existence of slots in every single case. 
In addition, choosing not to handle this is consistent with python's choice: stating the documetation of the stdlib's `copyreg._slotnames` function:
```
This assumes classes don't modify their
__slots__ attribute to misrepresent their slots after the class is
defined.
```