### PR TITLE
Alias CloudPickler in the cloudpickle namespace as Pickler

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -968,7 +968,7 @@ def dumps(obj, protocol=None):
 # including pickle's unloading functions in this namespace
 load = pickle.load
 loads = pickle.loads
-# alias CloudPickler in the namespace as Pickler for consistency with Python pickle API
+# alias CloudPickler in the namespace as Pickler for consistency with Python's pickle API
 Pickler = CloudPickler
 
 


### PR DESCRIPTION
Currently, the `Pickler` class in the `cloudpickle` namespace refers to `pickle.Pickler`. Certain libraries, such as PyTorch, leverage the `Pickler` class of a specified pickling module to serialize objects (see https://github.com/pytorch/pytorch/blob/fc5b79cd1c6020c20640128e43bac43fd636121e/torch/serialization.py#L290). When these libraries attempt reference the `cloudpickle.Pickler`, they obtain the `pickle.Pickler` class instead of `cloudpickle.CloudPickler`.

Working under the assumption that users referring to `cloudpickle.Pickler` desire/expect a reference to `cloudpickle.CloudPickler`, this PR aliases `cloudpickle.CloudPickler` as `cloudpickle.Pickler` and imports `pickle.Pickler` as `_Pickler` to avoid a naming conflict.