### PR TITLE
FIX load correct pickle file in a test

### DIFF
--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1192,7 +1192,7 @@ class CloudPickleTest(unittest.TestCase):
 
                 # Load a function with initial global variable that was
                 # pickled after a change in the global variable
-                with open({with_initial_globals_file!r},'rb') as f:
+                with open({with_modified_globals_file!r},'rb') as f:
                     func_with_modified_globals = pickle.load(f)
 
                 # assert the this unpickling did not modify the value of


### PR DESCRIPTION
We did not see that, but in #224, `test_function_from_dynamic_module_with_globals_modifications` was refactored, but at some point, the wrong pickle file is loaded. The CI passed anyway because the loaded function had the same global variable as the one in the already unpickled module.