### PR TITLE
Restore CloudPickler-scoped globals namespace isolation for pickled functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,9 @@
 
 - Global variables contained in pickle strings will override existing
   variables when loaded in their new environment. This restores the (previously
-  untested) behavior of cloudpickle prior to changes done in 0.6 and 0.6.1.
+  untested) behavior of cloudpickle prior to changes done in 0.5.4 for
+  functions defined in the `__main__` module,  and 0.6.0/1 for other dynamic
+  functions.
 
 
 0.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,8 @@
   ([issue #245](https://github.com/cloudpipe/cloudpickle/pull/245))
 
 - Global variables contained in pickle strings will override existing
-  variables when loaded in their new environment.
+  variables when loaded in their new environment. This restores the (previously
+  unstested) behavior of cloudpickle prior to changes done in 0.6 and 0.6.1.
 
 
 0.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 - Global variables contained in pickle strings will override existing
   variables when loaded in their new environment. This restores the (previously
-  unstested) behavior of cloudpickle prior to changes done in 0.6 and 0.6.1.
+  untested) behavior of cloudpickle prior to changes done in 0.6 and 0.6.1.
 
 
 0.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,11 @@
 - Add support for pickling interactively defined dataclasses.
   ([issue #245](https://github.com/cloudpipe/cloudpickle/pull/245))
 
-- Global variables contained in pickle strings will override existing
-  variables when loaded in their new environment. This restores the (previously
-  untested) behavior of cloudpickle prior to changes done in 0.5.4 for
-  functions defined in the `__main__` module,  and 0.6.0/1 for other dynamic
-  functions.
-
+- Global variables referenced by functions pickled by cloudpickle are now
+  unpickled in a new and isolated namespace scoped by the CloudPickler
+  instance. This restores the (previously untested) behavior of cloudpickle
+  prior to changes done in 0.5.4 for functions defined in the `__main__`
+  module, and 0.6.0/1 for other dynamic functions.
 
 0.7.0
 =====

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 - Add support for pickling interactively defined dataclasses.
   ([issue #245](https://github.com/cloudpipe/cloudpickle/pull/245))
 
+- Global variables contained in pickle strings will override existing
+  variables when loaded in their new environment.
+
 
 0.7.0
 =====

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -673,16 +673,17 @@ class CloudPickler(Pickler):
         # save the dict
         dct = func.__dict__
 
-        base_globals = self.globals_ref.get(id(func.__globals__), None)
-        if base_globals is None:
-            # For functions defined in a well behaved module use
-            # vars(func.__module__) for base_globals. This is necessary to
-            # share the global variables across multiple pickled functions from
-            # this module.
-            if func.__module__ is not None:
-                base_globals = func.__module__
-            else:
-                base_globals = {}
+        # base_globals represents the future global namespace of func at
+        # unpickling time. Looking it up and storing it in globals_ref allow
+        # functions sharing the same globals at pickling time to also
+        # share them at unpickling time, at one condition: since globals_ref is
+        # an attribute of a Cloudpickler instance, and that a new Pickler is
+        # created each time pickle.dump or pickle.dumps is called, functions
+        # also need to be saved within the same invokation of
+        # pickle.dump/pickle.dumps (for example: pickle.dumps([f1, f2])). There
+        # is no such limitation when using Cloudpickler.dump, as long as the
+        # multiple invokations are bound to the same Cloudpickler.
+        base_globals = self.globals_ref.get(id(func.__globals__), {})
         self.globals_ref[id(func.__globals__)] = base_globals
 
         return (code, f_globals, defaults, closure, dct, base_globals)

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -79,6 +79,9 @@ else:
     PY3 = True
 
 
+# Backward compatibility for cloudpickle from 0.5.4 to 0.6.1, in which
+# functions from the same dynamic module would share the same globals in their
+# depickling environment.
 # Container for the global namespace to ensure consistent unpickling of
 # functions defined in dynamic modules (modules not registed in sys.modules).
 _dynamic_modules_globals = weakref.WeakValueDictionary()

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -1146,6 +1146,9 @@ def _make_skel_func(code, cell_count, base_globals=None):
     if base_globals is None:
         base_globals = {}
     elif isinstance(base_globals, str):
+        # Backward compatibility for cloudpickle from 0.5.4 to 0.6.1, in which
+        # the globals of a depickled function were retrieved (if possible) by
+        # using the globals of the module with name base_globals
         base_globals_name = base_globals
         try:
             # First try to reuse the globals from the module containing the

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -683,8 +683,7 @@ class CloudPickler(Pickler):
         # pickle.dump/pickle.dumps (for example: pickle.dumps([f1, f2])). There
         # is no such limitation when using Cloudpickler.dump, as long as the
         # multiple invokations are bound to the same Cloudpickler.
-        base_globals = self.globals_ref.get(id(func.__globals__), {})
-        self.globals_ref[id(func.__globals__)] = base_globals
+        base_globals = self.globals_ref.setdefault(id(func.__globals__), {})
 
         return (code, f_globals, defaults, closure, dct, base_globals)
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -1083,12 +1083,12 @@ def _fill_function(*args):
     # - At pickling time, any dynamic global variable used by func is
     #   serialized by value (in state['globals']).
     # - At unpickling time, func's __globals__ attribute is initialized by
-    #   first retrieving the globals namespace from func's module by looking up
-    #   its __module__ attribute and then updated with state['globals'].
-
-    # That means that if any collision happens, the serialized global variables
-    # shipped with func will always override the globals already existing in
-    # func's new environment.
+    #   first retrieving an empty isolated namespace that will be shared
+    #   with other functions pickled from the same original module
+    #   by the same CloudPickler instance and then updated with the
+    #   content of state['globals'] to populate the shared isolated
+    #   namespace with all the global variables that are specifically
+    #   referenced for this function.
     func.__globals__.update(state['globals'])
 
     func.__defaults__ = state['defaults']

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -1098,13 +1098,13 @@ def _fill_function(*args):
 
     # - At pickling time, any dynamic global variable used by func is
     #   serialized by value (in state['globals']).
-    # - At unpickling time, func's  __globals__ will first mirror the globals
-    #   already existing in func's new module (predicted from func's __module__
-    #   attribute), and then be updated with state['globals'].
+    # - At unpickling time, func's __globals__ attribute is initialized by
+    #   first retrieving the globals namespace from func's module by looking up
+    #   its __module__ attribute and then updated with state['globals'].
 
     # That means that if any collision happens, the serialized global variables
     # shipped with func will always override the globals already existing in
-    # func's new environment
+    # func's new environment.
     func.__globals__.update(state['globals'])
 
     func.__defaults__ = state['defaults']

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -677,7 +677,7 @@ class CloudPickler(Pickler):
         # unpickling time. Looking it up and storing it in globals_ref allow
         # functions sharing the same globals at pickling time to also
         # share them once unpickled, at one condition: since globals_ref is
-        # an attribute of a Cloudpickler instance, and that a new Pickler is
+        # an attribute of a Cloudpickler instance, and that a new CloudPickler is
         # created each time pickle.dump or pickle.dumps is called, functions
         # also need to be saved within the same invokation of
         # cloudpickle.dump/cloudpickle.dumps (for example: cloudpickle.dumps([f1, f2])). There

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -676,11 +676,11 @@ class CloudPickler(Pickler):
         # base_globals represents the future global namespace of func at
         # unpickling time. Looking it up and storing it in globals_ref allow
         # functions sharing the same globals at pickling time to also
-        # share them at unpickling time, at one condition: since globals_ref is
+        # share them once unpickled, at one condition: since globals_ref is
         # an attribute of a Cloudpickler instance, and that a new Pickler is
         # created each time pickle.dump or pickle.dumps is called, functions
         # also need to be saved within the same invokation of
-        # pickle.dump/pickle.dumps (for example: pickle.dumps([f1, f2])). There
+        # cloudpickle.dump/cloudpickle.dumps (for example: cloudpickle.dumps([f1, f2])). There
         # is no such limitation when using Cloudpickler.dump, as long as the
         # multiple invokations are bound to the same Cloudpickler.
         base_globals = self.globals_ref.setdefault(id(func.__globals__), {})

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -1127,6 +1127,9 @@ def _make_skel_func(code, cell_count, base_globals=None):
         code and the correct number of cells in func_closure.  All other
         func attributes (e.g. func_globals) are empty.
     """
+    # This is backward-compatibility code: for cloudpickle versions between
+    # 0.5.4 and 0.7, base_globals could be a string or None. base_globals
+    # should now always be a dictionary.
     if base_globals is None or isinstance(base_globals, str):
         base_globals = {}
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -451,57 +451,6 @@ class CloudPickleTest(unittest.TestCase):
         mod1, mod2 = pickle_depickle([mod, mod])
         self.assertEqual(id(mod1), id(mod2))
 
-    def test_dynamic_modules_globals(self):
-        # _dynamic_modules_globals is a WeakValueDictionary, so if a value
-        # in this dict (containing a set of global variables from a dynamic
-        # module created in the parent process) has no other reference than in
-        # this dict in the child process, it will be garbage collected.
-
-        # We first create a module
-        mod = types.ModuleType('mod')
-        code = '''
-        x = 1
-        def func():
-            return
-        '''
-        exec(textwrap.dedent(code), mod.__dict__)
-
-        pickled_module_path = os.path.join(self.tmpdir, 'mod_f.pkl')
-        child_process_script = '''
-        import pickle
-        from cloudpickle.cloudpickle import _dynamic_modules_globals
-        import gc
-        with open("{pickled_module_path}", 'rb') as f:
-            func = pickle.load(f)
-
-        # A dictionnary storing the globals of the newly unpickled function
-        # should have been created
-        assert list(_dynamic_modules_globals.keys()) == ['mod']
-
-        # func.__globals__ is the only non-weak reference to
-        # _dynamic_modules_globals['mod']. By deleting func, we delete also
-        # _dynamic_modules_globals['mod']
-        del func
-        gc.collect()
-
-        # There is no reference to the globals of func since func has been
-        # deleted and _dynamic_modules_globals is a WeakValueDictionary,
-        # so _dynamic_modules_globals should now be empty
-        assert list(_dynamic_modules_globals.keys()) == []
-        '''
-
-        child_process_script = child_process_script.format(
-                pickled_module_path=_escape(pickled_module_path))
-
-        try:
-            with open(pickled_module_path, 'wb') as f:
-                cloudpickle.dump(mod.func, f, protocol=self.protocol)
-
-            assert_run_python_script(textwrap.dedent(child_process_script))
-
-        finally:
-            os.unlink(pickled_module_path)
-
     def test_module_locals_behavior(self):
         # Makes sure that a local function defined in another module is
         # correctly serialized. This notably checks that the globals are
@@ -1151,102 +1100,15 @@ class CloudPickleTest(unittest.TestCase):
             # f1 is unpickled another time, but because it comes from another
             # pickle string than pickled_f1 and pickled_f0, it will not share
             # the same globals as the latter two.
-            cloned_f1_with_new_globals = cloudpickle.loads(pickled_f1)
+            new_cloned_f1 = pickle.loads(pickled_f1)
+            assert new_cloned_f1.__globals__ is not cloned_f1.__globals__
+            assert new_cloned_f1.__globals__ is not f1.__globals__
 
-            # get the value of cloned_f1_with_new_globals's VARIABLE
-            new_global_var = cloned_f1_with_new_globals()
+            # get the value of new_cloned_f1's VARIABLE
+            new_global_var = new_cloned_f1()
             assert new_global_var == "default_value", new_global_var
         finally:
             _TEST_GLOBAL_VARIABLE = orig_value
-
-    def test_function_from_dynamic_module_with_globals_modifications(self):
-        # This test verifies that the global variable state of a function
-        # defined in a dynamic module in a child process are not reset by
-        # subsequent uplickling.
-
-        # first, we create a dynamic module in the parent process
-        mod = types.ModuleType('mod')
-        code = '''
-        GLOBAL_STATE = "initial value"
-
-        def func_defined_in_dynamic_module(v=None):
-            global GLOBAL_STATE
-            if v is not None:
-                GLOBAL_STATE = v
-            return GLOBAL_STATE
-        '''
-        exec(textwrap.dedent(code), mod.__dict__)
-
-        with_initial_globals_file = os.path.join(
-            self.tmpdir, 'function_with_initial_globals.pkl')
-        with_modified_globals_file = os.path.join(
-            self.tmpdir, 'function_with_modified_globals.pkl')
-
-        try:
-            # Simple sanity check on the function's output
-            assert mod.func_defined_in_dynamic_module() == "initial value"
-
-            # The function of mod is pickled two times, with two different
-            # values for the global variable GLOBAL_STATE.
-            # Then we launch a child process that sequentially unpickles the
-            # two functions. Those unpickle functions should share the same
-            # global variables in the child process:
-            # Once the first function gets unpickled, mod is created and
-            # tracked in the child environment. This is state is preserved
-            # when unpickling the second function whatever the global variable
-            # GLOBAL_STATE's value at the time of pickling.
-
-            with open(with_initial_globals_file, 'wb') as f:
-                cloudpickle.dump(mod.func_defined_in_dynamic_module, f)
-
-            # Change the mod's global variable
-            mod.GLOBAL_STATE = 'changed value'
-
-            # At this point, mod.func_defined_in_dynamic_module()
-            # returns the updated value. Let's pickle it again.
-            assert mod.func_defined_in_dynamic_module() == 'changed value'
-            with open(with_modified_globals_file, 'wb') as f:
-                cloudpickle.dump(mod.func_defined_in_dynamic_module, f,
-                                 protocol=self.protocol)
-
-            child_process_code = """
-                import pickle
-
-                with open({with_initial_globals_file!r},'rb') as f:
-                    func_with_initial_globals = pickle.load(f)
-
-                # At this point, a module called 'mod' should exist in
-                # _dynamic_modules_globals. Further function loading
-                # will use the globals living in mod.
-
-                assert func_with_initial_globals() == 'initial value'
-
-                # Load a function with initial global variable that was
-                # pickled after a change in the global variable
-                with open({with_modified_globals_file!r},'rb') as f:
-                    func_with_modified_globals = pickle.load(f)
-
-                # assert that unpickling this function has overridden the
-                # previous value of GLOBAL_STATE
-                assert func_with_modified_globals() == 'changed value'
-
-                # Update the value from the child process and check that
-                # unpickling again resets our change.
-                assert func_with_initial_globals('new value') == 'new value'
-                assert func_with_modified_globals() == 'new value'
-
-                with open({with_initial_globals_file!r},'rb') as f:
-                    func_with_initial_globals = pickle.load(f)
-                assert func_with_initial_globals() == 'initial value'
-                assert func_with_modified_globals() == 'initial value'
-            """.format(
-                with_initial_globals_file=_escape(with_initial_globals_file),
-                with_modified_globals_file=_escape(with_modified_globals_file))
-            assert_run_python_script(textwrap.dedent(child_process_code))
-
-        finally:
-            os.unlink(with_initial_globals_file)
-            os.unlink(with_modified_globals_file)
 
     @pytest.mark.skipif(sys.version_info >= (3, 0),
                         reason="hardcoded pickle bytes for 2.7")


### PR DESCRIPTION
This PR changes the way globals collisions are handled:

* before, already existing globals would override globals shipped in a function's pickle string
* now, it is the opposite: any global shipped with a function will have the priority over already existing globals in the depickling environment.

The tests are accordingly updated. Note that #216 did not add any new tests, but simply parametrized existing ones. 

EDIT: For the record, the previous behavior (silently override globals shipped with the functions) introduced regressions reported by users of downstream projects. Here is the list of issues related to it:

* https://github.com/joblib/joblib/issues/836
* https://github.com/joblib/joblib/issues/833
* #230 
* #214 

@ogrisel it is a good PR to trigger the new downstream integration builds!