### PR TITLE
Fix pickling dataclasses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+0.8.0
+=====
+
+- Add support for pickling interactively defined dataclasses.
+  ([issue #245](https://github.com/cloudpipe/cloudpickle/pull/245))
+
+
 0.7.0
 =====
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -266,6 +266,11 @@ else:
                 yield op, instr.arg
 
 
+def _normalize_dataclass_dict(clsdict):
+    dataclass_fields = clsdict.get('__dataclass_fields__', [])
+    for key in dataclass_fields:
+        dataclass_fields[key].metadata = dict(dataclass_fields[key].metadata)
+
 class CloudPickler(Pickler):
 
     dispatch = Pickler.dispatch.copy()
@@ -542,6 +547,8 @@ class CloudPickler(Pickler):
         # Create and memoize an skeleton class with obj's name and bases.
         tp = type(obj)
         self.save_reduce(tp, (obj.__name__, obj.__bases__, type_kwargs), obj=obj)
+
+        _normalize_dataclass_dict(clsdict)
 
         # Now save the rest of obj's __dict__. Any references to obj
         # encountered while saving will point to the skeleton class.

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -271,7 +271,7 @@ def _normalize_dataclass_dict(clsdict):
     Replace mappingproxy fields (non pickleable) in dataclass
     __dict__ with dict.
     """
-    dataclass_fields = clsdict.get('__dataclass_fields__', [])
+    dataclass_fields = clsdict.get('__dataclass_fields__', {})
     for key in dataclass_fields:
         dataclass_fields[key].metadata = dict(dataclass_fields[key].metadata)
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -267,6 +267,10 @@ else:
 
 
 def _normalize_dataclass_dict(clsdict):
+    """
+    Replace mappingproxy fields (non pickleable) in dataclass
+    __dict__ with dict.
+    """
     dataclass_fields = clsdict.get('__dataclass_fields__', [])
     for key in dataclass_fields:
         dataclass_fields[key].metadata = dict(dataclass_fields[key].metadata)

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -63,7 +63,7 @@ import weakref
 DEFAULT_PROTOCOL = pickle.HIGHEST_PROTOCOL
 
 
-if sys.version < '3':
+if sys.version_info[0] < 3:  # pragma: no branch
     from pickle import Pickler
     try:
         from cStringIO import StringIO
@@ -128,7 +128,7 @@ def _make_cell_set_template_code():
     # NOTE: we are marking the cell variable as a free variable intentionally
     # so that we simulate an inner function instead of the outer function. This
     # is what gives us the ``nonlocal`` behavior in a Python 2 compatible way.
-    if not PY3:
+    if not PY3:  # pragma: no branch
         return types.CodeType(
             co.co_argcount,
             co.co_nlocals,
@@ -229,14 +229,14 @@ _BUILTIN_TYPE_CONSTRUCTORS = {
 }
 
 
-if sys.version_info < (3, 4):
+if sys.version_info < (3, 4):  # pragma: no branch
     def _walk_global_ops(code):
         """
         Yield (opcode, argument number) tuples for all
         global-referencing instructions in *code*.
         """
         code = getattr(code, 'co_code', b'')
-        if not PY3:
+        if not PY3:  # pragma: no branch
             code = map(ord, code)
 
         n = len(code)
@@ -293,7 +293,7 @@ class CloudPickler(Pickler):
 
     dispatch[memoryview] = save_memoryview
 
-    if not PY3:
+    if not PY3:  # pragma: no branch
         def save_buffer(self, obj):
             self.save(str(obj))
 
@@ -315,7 +315,7 @@ class CloudPickler(Pickler):
         """
         Save a code object
         """
-        if PY3:
+        if PY3:  # pragma: no branch
             args = (
                 obj.co_argcount, obj.co_kwonlyargcount, obj.co_nlocals, obj.co_stacksize,
                 obj.co_flags, obj.co_code, obj.co_consts, obj.co_names, obj.co_varnames,
@@ -393,7 +393,7 @@ class CloudPickler(Pickler):
         # So we pickle them here using save_reduce; have to do it differently
         # for different python versions.
         if not hasattr(obj, '__code__'):
-            if PY3:
+            if PY3:  # pragma: no branch
                 rv = obj.__reduce_ex__(self.proto)
             else:
                 if hasattr(obj, '__self__'):
@@ -730,7 +730,7 @@ class CloudPickler(Pickler):
         if obj.__self__ is None:
             self.save_reduce(getattr, (obj.im_class, obj.__name__))
         else:
-            if PY3:
+            if PY3:  # pragma: no branch
                 self.save_reduce(types.MethodType, (obj.__func__, obj.__self__), obj=obj)
             else:
                 self.save_reduce(types.MethodType, (obj.__func__, obj.__self__, obj.__self__.__class__),
@@ -783,7 +783,7 @@ class CloudPickler(Pickler):
         save(stuff)
         write(pickle.BUILD)
 
-    if not PY3:
+    if not PY3:  # pragma: no branch
         dispatch[types.InstanceType] = save_inst
 
     def save_property(self, obj):
@@ -883,7 +883,7 @@ class CloudPickler(Pickler):
 
     try:               # Python 2
         dispatch[file] = save_file
-    except NameError:  # Python 3
+    except NameError:  # Python 3  # pragma: no branch
         dispatch[io.TextIOWrapper] = save_file
 
     dispatch[type(Ellipsis)] = save_ellipsis
@@ -904,11 +904,11 @@ class CloudPickler(Pickler):
 
     dispatch[logging.RootLogger] = save_root_logger
 
-    if hasattr(types, "MappingProxyType"):
-        def _save_mappingproxy(self, obj):
+    if hasattr(types, "MappingProxyType"):  # pragma: no branch
+        def save_mappingproxy(self, obj):
             self.save_reduce(types.MappingProxyType, (dict(obj),), obj=obj)
 
-        dispatch[types.MappingProxyType] = _save_mappingproxy
+        dispatch[types.MappingProxyType] = save_mappingproxy
 
     """Special functions for Add-on libraries"""
     def inject_addons(self):
@@ -1219,7 +1219,7 @@ def _getobject(modname, attribute):
 
 """ Use copy_reg to extend global pickle definitions """
 
-if sys.version_info < (3, 4):
+if sys.version_info < (3, 4):  # pragma: no branch
     method_descriptor = type(str.upper)
 
     def _reduce_method_descriptor(obj):

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1344,12 +1344,12 @@ class CloudPickleTest(unittest.TestCase):
                 with pytest.raises(AttributeError):
                     obj.non_registered_attribute = 1
 
+    @pytest.mark.skipif(sys.version_info < (3, 7),
+                        reason="dataclasses not implemented before 3.7")
     def test_dataclass(self):
-        from dataclasses import dataclass
+        from dataclasses import make_dataclass
 
-        @dataclass
-        class DataClass:
-            field: int
+        DataClass = make_dataclass('DataClass', [('x', int)])
 
         pickle_depickle(DataClass, protocol=self.protocol)
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1357,7 +1357,7 @@ class CloudPickleTest(unittest.TestCase):
         data = DataClass(x=42)
 
         pickle_depickle(DataClass, protocol=self.protocol)
-        assert data.x == pickle_depickle(data).x == 42
+        assert data.x == pickle_depickle(data, protocol=self.protocol).x == 42
 
 
 class Protocol2CloudPickleTest(CloudPickleTest):

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1344,6 +1344,15 @@ class CloudPickleTest(unittest.TestCase):
                 with pytest.raises(AttributeError):
                     obj.non_registered_attribute = 1
 
+    def test_dataclass(self):
+        from dataclasses import dataclass
+
+        @dataclass
+        class DataClass:
+            field: int
+
+        pickle_depickle(DataClass, protocol=self.protocol)
+
 
 class Protocol2CloudPickleTest(CloudPickleTest):
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1344,11 +1344,20 @@ class CloudPickleTest(unittest.TestCase):
                 with pytest.raises(AttributeError):
                     obj.non_registered_attribute = 1
 
+    @unittest.skipIf(not hasattr(types, "MappingProxyType"),
+                     "Old versions of Python do not have this type.")
+    def test_mappingproxy(self):
+        mp = types.MappingProxyType({"some_key": "some value"})
+        assert mp == pickle_depickle(mp, protocol=self.protocol)
+
     def test_dataclass(self):
         dataclasses = pytest.importorskip("dataclasses")
 
         DataClass = dataclasses.make_dataclass('DataClass', [('x', int)])
+        data = DataClass(x=42)
+
         pickle_depickle(DataClass, protocol=self.protocol)
+        assert data.x == pickle_depickle(data).x == 42
 
 
 class Protocol2CloudPickleTest(CloudPickleTest):

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1344,13 +1344,10 @@ class CloudPickleTest(unittest.TestCase):
                 with pytest.raises(AttributeError):
                     obj.non_registered_attribute = 1
 
-    @pytest.mark.skipif(sys.version_info < (3, 7),
-                        reason="dataclasses not implemented before 3.7")
     def test_dataclass(self):
-        from dataclasses import make_dataclass
+        dataclasses = pytest.importorskip("dataclasses")
 
-        DataClass = make_dataclass('DataClass', [('x', int)])
-
+        DataClass = dataclasses.make_dataclass('DataClass', [('x', int)])
         pickle_depickle(DataClass, protocol=self.protocol)
 
 


### PR DESCRIPTION
The metadata field in clsdict['__dataclass_fields__'] was a mappingproxy object, which can't be pickled. This PR converts it to a dict.