### PR TITLE
Implement dynamic class provenance tracking to fix isinstance semantics and add support for dynamically defined enums

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+0.9.0
+=====
+
+- Track the provenance of dynamic classes and enums so as to preseve the
+  usual `isinstance` relationship between pickled objects and their
+  original class defintions.
+  ([issue #246](https://github.com/cloudpipe/cloudpickle/pull/246))
+
 0.8.0
 =====
 
@@ -9,7 +17,6 @@
   instance. This restores the (previously untested) behavior of cloudpickle
   prior to changes done in 0.5.4 for functions defined in the `__main__`
   module, and 0.6.0/1 for other dynamic functions.
-
 
 0.7.0
 =====

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,18 +1,14 @@
 0.8.0
 =====
 
+- Add support for pickling interactively defined dataclasses.
+  ([issue #245](https://github.com/cloudpipe/cloudpickle/pull/245))
+
 - Global variables referenced by functions pickled by cloudpickle are now
   unpickled in a new and isolated namespace scoped by the CloudPickler
   instance. This restores the (previously untested) behavior of cloudpickle
   prior to changes done in 0.5.4 for functions defined in the `__main__`
   module, and 0.6.0/1 for other dynamic functions.
-
-- Add support for pickling interactively defined dataclasses.
-  ([issue #245](https://github.com/cloudpipe/cloudpickle/pull/245))
-
-- Add support for pickling interactively defined Enum subclasses and
-  their instances.
-  ([issue #246](https://github.com/cloudpipe/cloudpickle/pull/246))
 
 
 0.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,13 @@
-1.0.0
+1.1.0
 =====
 
 - Track the provenance of dynamic classes and enums so as to preseve the
   usual `isinstance` relationship between pickled objects and their
   original class defintions.
   ([issue #246](https://github.com/cloudpipe/cloudpickle/pull/246))
+
+1.0.0
+=====
 
 - Fix a bug making functions with keyword-only arguments forget the default
   values of these arguments after being pickled.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,19 @@
 0.8.0
 =====
 
-- Add support for pickling interactively defined dataclasses.
-  ([issue #245](https://github.com/cloudpipe/cloudpickle/pull/245))
-
 - Global variables referenced by functions pickled by cloudpickle are now
   unpickled in a new and isolated namespace scoped by the CloudPickler
   instance. This restores the (previously untested) behavior of cloudpickle
   prior to changes done in 0.5.4 for functions defined in the `__main__`
   module, and 0.6.0/1 for other dynamic functions.
+
+- Add support for pickling interactively defined dataclasses.
+  ([issue #245](https://github.com/cloudpipe/cloudpickle/pull/245))
+
+- Add support for pickling interactively defined Enum subclasses and
+  their instances.
+  ([issue #246](https://github.com/cloudpipe/cloudpickle/pull/246))
+
 
 0.7.0
 =====

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -540,16 +540,11 @@ class CloudPickler(Pickler):
         """
         members = dict((e.name, e.value) for e in obj)
 
-        if obj.__doc__ is not obj.__base__.__doc__:
-            doc = obj.__doc__
-        else:
-            doc = None
-
         # Python 2.7 with enum34 can have no qualname:
         qualname = getattr(obj, "__qualname__", None)
 
         self.save_reduce(_make_skeleton_enum,
-                         (obj.__bases__, obj.__name__, qualname, members, doc,
+                         (obj.__bases__, obj.__name__, qualname, members,
                           obj.__module__, _ensure_tracking(obj), None),
                          obj=obj)
 
@@ -1249,7 +1244,7 @@ def _rehydrate_skeleton_class(skeleton_class, class_dict):
     return skeleton_class
 
 
-def _make_skeleton_enum(bases, name, qualname, members, doc, module,
+def _make_skeleton_enum(bases, name, qualname, members, module,
                         class_tracker_id, extra):
     """Build dynamic enum with an empty __dict__ to be filled once memoized
 
@@ -1280,8 +1275,6 @@ def _make_skeleton_enum(bases, name, qualname, members, doc, module,
     if qualname is not None:
         enum_class.__qualname__ = qualname
 
-    if doc is not None:
-        enum_class.__doc__ = doc
     return _lookup_class_or_track(class_tracker_id, enum_class)
 
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -64,7 +64,9 @@ from enum import Enum
 # communication speed over compatibility:
 DEFAULT_PROTOCOL = pickle.HIGHEST_PROTOCOL
 
-
+# Track the provenance of reconstructed dynamic classes to make it possible
+# to reconcyle instances with a singleton class definition when appropriate
+# and preserve the usual "isinstance" semantics of Python objects.
 _DYNAMIC_CLASS_TRACKER_BY_CLASS = weakref.WeakKeyDictionary()
 _DYNAMIC_CLASS_TRACKER_BY_ID = weakref.WeakValueDictionary()
 _DYNAMIC_CLASS_TRACKER_LOCK = threading.Lock()
@@ -523,10 +525,7 @@ class CloudPickler(Pickler):
         if issubclass(obj, Enum):
             return self._save_dynamic_enum(obj)
 
-        class_tracker_id = _ensure_tracking(obj)
-
         clsdict = dict(obj.__dict__)  # copy dict proxy to a dict
-        clsdict["_cloudpickle_class_tracker_id"] = class_tracker_id
         clsdict.pop('__weakref__', None)
 
         # For ABCMeta in python3.7+, remove _abc_impl as it is not picklable.
@@ -582,8 +581,11 @@ class CloudPickler(Pickler):
         write(pickle.MARK)
 
         # Create and memoize an skeleton class with obj's name and bases.
+        extra = {"class_tracker_id": _ensure_tracking(obj)}
         tp = type(obj)
-        self.save_reduce(tp, (obj.__name__, obj.__bases__, type_kwargs), obj=obj)
+        self.save_reduce(_make_skeleton_class,
+                         (tp, obj.__name__, obj.__bases__, type_kwargs, extra),
+                         obj=obj)
 
         # Now save the rest of obj's __dict__. Any references to obj
         # encountered while saving will point to the skeleton class.
@@ -1164,13 +1166,19 @@ def _make_skel_func(code, cell_count, base_globals=None):
     return types.FunctionType(code, base_globals, None, None, closure)
 
 
+def _make_skeleton_class(type_constructor, name, bases, type_kwargs,
+                         extra):
+    class_tracker_id = extra.get("class_tracker_id")
+    skeleton_class = type_constructor(name, bases, type_kwargs)
+    return _lookup_class_or_track(class_tracker_id, skeleton_class)
+
+
 def _rehydrate_skeleton_class(skeleton_class, class_dict):
     """Put attributes from `class_dict` back on `skeleton_class`.
 
     See CloudPickler.save_dynamic_class for more info.
     """
     registry = None
-    class_tracker_id = class_dict.pop("_cloudpickle_class_tracker_id", None)
 
     for attrname, attr in class_dict.items():
         if attrname == "_abc_impl":
@@ -1181,7 +1189,7 @@ def _rehydrate_skeleton_class(skeleton_class, class_dict):
         for subclass in registry:
             skeleton_class.register(subclass)
 
-    return _lookup_class_or_track(class_tracker_id, skeleton_class)
+    return skeleton_class
 
 
 def _make_dynamic_enum(base, name, elements, doc, module, class_tracker_id,

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -519,7 +519,7 @@ class CloudPickler(Pickler):
         for attrname in ["_generate_next_value_", "_member_names_",
                          "_member_map_", "_member_type_",
                          "_value2member_map_"]:
-            clsdict.pop(attrname)
+            clsdict.pop(attrname, None)
         for member in members:
             clsdict.pop(member)
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -55,17 +55,12 @@ import sys
 import traceback
 import types
 import weakref
+from enum import Enum
 
 # cloudpickle is meant for inter process communication: we expect all
 # communicating processes to run the same Python version hence we favor
 # communication speed over compatibility:
 DEFAULT_PROTOCOL = pickle.HIGHEST_PROTOCOL
-
-
-try:
-    from enum import Enum
-except ImportError:
-    Enum = None
 
 
 if sys.version_info[0] < 3:  # pragma: no branch
@@ -492,7 +487,7 @@ class CloudPickler(Pickler):
         functions, or that otherwise can't be serialized as attribute lookups
         from global modules.
         """
-        if Enum is not None and issubclass(obj, Enum):
+        if issubclass(obj, Enum):
             return self._save_dynamic_enum(obj)
 
         clsdict = dict(obj.__dict__)  # copy dict proxy to a dict

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -475,11 +475,11 @@ class CloudPickler(Pickler):
         # XXX: shall we pass type and start kwargs? If so how to retrieve the
         # correct info from obj.
         elements = dict((e.name, e.value) for e in obj)
-        extra = {
-            "__doc__": obj.__doc__,
-            "__module__": obj.__module__,
-            "__qualname__": obj.__qualname__,
-        }
+        attrnames = ["__doc__", "__module__", "__qualname__"]
+        extra = dict(
+            (attrname[2:-2], getattr(obj, attrname))
+            for attrname in attrnames if hasattr(obj, attrname)
+        )
         self.save_reduce(_make_dynamic_enum,
                          (obj.__base__, obj.__name__, elements, extra),
                          obj=obj)
@@ -1152,9 +1152,10 @@ def _rehydrate_skeleton_class(skeleton_class, class_dict):
 
 
 def _make_dynamic_enum(base, name, elements, extra):
-    cls = base(name, elements, module=extra["__module__"],
-               qualname=extra["__qualname__"])
-    cls.__doc__ = extra["__doc__"]
+    doc = extra.pop("doc", None)
+    cls = base(name, elements, **extra)
+    if doc is not None:
+        cls.__doc__ = doc
     return cls
 
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -1259,8 +1259,8 @@ def _make_skeleton_enum(bases, name, qualname, members, module,
     The "extra" variable is meant to be a dict (or None) that can be used for
     forward compatibility shall the need arise.
     """
-    # enums always inherit from their base Enum class at the last subclass
-    # position:
+    # enums always inherit from their base Enum class at the last position in
+    # the list of base classes:
     enum_base = bases[-1]
     metacls = enum_base.__class__
     _, first_enum = enum_base._get_mixins_(bases)

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -55,6 +55,8 @@ import sys
 import traceback
 import types
 import weakref
+import uuid
+import threading
 from enum import Enum
 
 # cloudpickle is meant for inter process communication: we expect all
@@ -62,6 +64,10 @@ from enum import Enum
 # communication speed over compatibility:
 DEFAULT_PROTOCOL = pickle.HIGHEST_PROTOCOL
 
+
+_DYNAMIC_CLASS_TRACKER_BY_CLASS = weakref.WeakKeyDictionary()
+_DYNAMIC_CLASS_TRACKER_BY_ID = weakref.WeakValueDictionary()
+_DYNAMIC_CLASS_TRACKER_LOCK = threading.Lock()
 
 if sys.version_info[0] < 3:  # pragma: no branch
     from pickle import Pickler
@@ -77,6 +83,25 @@ else:
     from io import BytesIO as StringIO
     string_types = (str,)
     PY3 = True
+
+
+def _ensure_tracking(class_def):
+    with _DYNAMIC_CLASS_TRACKER_LOCK:
+        class_tracker_id = _DYNAMIC_CLASS_TRACKER_BY_CLASS.get(class_def)
+        if class_tracker_id is None:
+            class_tracker_id = uuid.uuid4().hex
+            _DYNAMIC_CLASS_TRACKER_BY_CLASS[class_def] = class_tracker_id
+            _DYNAMIC_CLASS_TRACKER_BY_ID[class_tracker_id] = class_def
+    return class_tracker_id
+
+
+def _lookup_class_or_track(class_tracker_id, class_def):
+    if class_tracker_id is not None:
+        with _DYNAMIC_CLASS_TRACKER_LOCK:
+            class_def = _DYNAMIC_CLASS_TRACKER_BY_ID.setdefault(
+                class_tracker_id, class_def)
+            _DYNAMIC_CLASS_TRACKER_BY_CLASS[class_def] = class_tracker_id
+    return class_def
 
 
 def _make_cell_set_template_code():
@@ -467,6 +492,8 @@ class CloudPickler(Pickler):
         EnumMeta metaclass has complex initialization that makes the Enum
         subclasses hold references to their own instances.
         """
+        class_tracker_id = _ensure_tracking(obj)
+
         # XXX: shall we pass type and start kwargs? If so how to retrieve the
         # correct info from obj.
         elements = dict((e.name, e.value) for e in obj)
@@ -482,7 +509,7 @@ class CloudPickler(Pickler):
 
         self.save_reduce(_make_dynamic_enum,
                          (obj.__base__, obj.__name__, elements, doc,
-                          obj.__module__, extra),
+                          obj.__module__, class_tracker_id, extra),
                          obj=obj)
 
     def save_dynamic_class(self, obj):
@@ -496,7 +523,10 @@ class CloudPickler(Pickler):
         if issubclass(obj, Enum):
             return self._save_dynamic_enum(obj)
 
+        class_tracker_id = _ensure_tracking(obj)
+
         clsdict = dict(obj.__dict__)  # copy dict proxy to a dict
+        clsdict["_cloudpickle_class_tracker_id"] = class_tracker_id
         clsdict.pop('__weakref__', None)
 
         # For ABCMeta in python3.7+, remove _abc_impl as it is not picklable.
@@ -1140,6 +1170,8 @@ def _rehydrate_skeleton_class(skeleton_class, class_dict):
     See CloudPickler.save_dynamic_class for more info.
     """
     registry = None
+    class_tracker_id = class_dict.pop("_cloudpickle_class_tracker_id", None)
+
     for attrname, attr in class_dict.items():
         if attrname == "_abc_impl":
             registry = attr
@@ -1149,26 +1181,15 @@ def _rehydrate_skeleton_class(skeleton_class, class_dict):
         for subclass in registry:
             skeleton_class.register(subclass)
 
-    return skeleton_class
+    return _lookup_class_or_track(class_tracker_id, skeleton_class)
 
 
-def _make_dynamic_enum(base, name, elements, doc, module, extra):
-    if module == "__main__":
-        # Special case: try to lookup enum from main module to make it possible
-        # to use physical comparison with enum instances returned by a remote
-        # function calls whose results are communicated back to the main Python
-        # process with cloudpickle.
-        try:
-            lookedup_enum = getattr(sys.modules["__main__"], name)
-            assert issubclass(lookedup_enum, Enum)
-            return lookedup_enum
-        except (KeyError, AttributeError):
-            # Fall-back to dynamic instanciation.
-            pass
-    cls = base(name, elements, module=module, **extra)
+def _make_dynamic_enum(base, name, elements, doc, module, class_tracker_id,
+                       extra):
+    class_def = base(name, elements, module=module, **extra)
     if doc is not None:
-        cls.__doc__ = doc
-    return cls
+        class_def.__doc__ = doc
+    return _lookup_class_or_track(class_tracker_id, class_def)
 
 
 def _is_dynamic(module):

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -1147,10 +1147,9 @@ def _rehydrate_skeleton_class(skeleton_class, class_dict):
 
 
 def _make_dynamic_enum(base, name, elements, extra):
-    doc = extra.pop("doc", None)
+    doc = extra.pop("doc")
     cls = base(name, elements, **extra)
-    if doc is not None:
-        cls.__doc__ = doc
+    cls.__doc__ = doc
     return cls
 
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -44,7 +44,6 @@ from __future__ import print_function
 
 import dis
 from functools import partial
-import importlib
 import io
 import itertools
 import logging
@@ -61,6 +60,12 @@ import weakref
 # communicating processes to run the same Python version hence we favor
 # communication speed over compatibility:
 DEFAULT_PROTOCOL = pickle.HIGHEST_PROTOCOL
+
+
+try:
+    from enum import Enum
+except ImportError:
+    Enum = None
 
 
 if sys.version_info[0] < 3:  # pragma: no branch
@@ -460,6 +465,25 @@ class CloudPickler(Pickler):
                             # then discards the reference to it
                             self.write(pickle.POP)
 
+    def _save_dynamic_enum(self, obj):
+        """Special handling for dynamic Enum subclasses
+
+        Use the Enum functional API as the EnumMeta metaclass has complex
+        initialization and and that make the Enum classes hold references to
+        their own instances.
+        """
+        # XXX: shall we pass type and start kwargs? If so how to retrieve the
+        # correct info from obj.
+        elements = dict((e.name, e.value) for e in obj)
+        extra = {
+            "__doc__": obj.__doc__,
+            "__module__": obj.__module__,
+            "__qualname__": obj.__qualname__,
+        }
+        self.save_reduce(_make_dynamic_enum,
+                         (obj.__base__, obj.__name__, elements, extra),
+                         obj=obj)
+
     def save_dynamic_class(self, obj):
         """
         Save a class that can't be stored as module global.
@@ -468,6 +492,9 @@ class CloudPickler(Pickler):
         functions, or that otherwise can't be serialized as attribute lookups
         from global modules.
         """
+        if Enum is not None and issubclass(obj, Enum):
+            return self._save_dynamic_enum(obj)
+
         clsdict = dict(obj.__dict__)  # copy dict proxy to a dict
         clsdict.pop('__weakref__', None)
 
@@ -1122,6 +1149,13 @@ def _rehydrate_skeleton_class(skeleton_class, class_dict):
             skeleton_class.register(subclass)
 
     return skeleton_class
+
+
+def _make_dynamic_enum(base, name, elements, extra):
+    cls = base(name, elements, module=extra["__module__"],
+               qualname=extra["__qualname__"])
+    cls.__doc__ = extra["__doc__"]
+    return cls
 
 
 def _is_dynamic(module):

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -463,9 +463,9 @@ class CloudPickler(Pickler):
     def _save_dynamic_enum(self, obj):
         """Special handling for dynamic Enum subclasses
 
-        Use the Enum functional API as the EnumMeta metaclass has complex
-        initialization and and that make the Enum classes hold references to
-        their own instances.
+        Use the Enum functional API (inherited from EnumMeta.__call__) as the
+        EnumMeta metaclass has complex initialization that makes the Enum
+        subclasses hold references to their own instances.
         """
         # XXX: shall we pass type and start kwargs? If so how to retrieve the
         # correct info from obj.

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -57,7 +57,12 @@ import types
 import weakref
 import uuid
 import threading
-from enum import Enum
+
+
+try:
+    from enum import Enum
+except ImportError:
+    Enum = None
 
 # cloudpickle is meant for inter process communication: we expect all
 # communicating processes to run the same Python version hence we favor
@@ -522,7 +527,7 @@ class CloudPickler(Pickler):
         functions, or that otherwise can't be serialized as attribute lookups
         from global modules.
         """
-        if issubclass(obj, Enum):
+        if Enum is not None and issubclass(obj, Enum):
             return self._save_dynamic_enum(obj)
 
         clsdict = dict(obj.__dict__)  # copy dict proxy to a dict

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -1263,7 +1263,6 @@ def _make_skeleton_enum(bases, name, qualname, members, module,
     # the list of base classes:
     enum_base = bases[-1]
     metacls = enum_base.__class__
-    _, first_enum = enum_base._get_mixins_(bases)
     classdict = metacls.__prepare__(name, bases)
 
     for member_name, member_value in members.items():

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -42,6 +42,7 @@ except ImportError:
 import cloudpickle
 from cloudpickle.cloudpickle import _is_dynamic
 from cloudpickle.cloudpickle import _make_empty_cell, cell_set
+from cloudpickle.cloudpickle import _extract_class_dict
 
 from .testutils import subprocess_pickle_echo
 from .testutils import assert_run_python_script
@@ -69,6 +70,29 @@ def pickle_depickle(obj, protocol=cloudpickle.DEFAULT_PROTOCOL):
 def _escape(raw_filepath):
     # Ugly hack to embed filepaths in code templates for windows
     return raw_filepath.replace("\\", r"\\\\")
+
+
+def test_extract_class_dict():
+    class A(int):
+        def method(self):
+            return "a"
+
+    class B:
+        B_CONSTANT = 42
+
+        def method(self):
+            return "b"
+
+    class C(A, B):
+        C_CONSTANT = 43
+
+        def method_c(self):
+            return "c"
+
+    clsdict = _extract_class_dict(C)
+    assert sorted(clsdict.keys()) == ["C_CONSTANT", "method_c"]
+    assert clsdict["C_CONSTANT"] == 43
+    assert clsdict["method_c"](C()) == C().method_c()
 
 
 class CloudPickleTest(unittest.TestCase):

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1385,7 +1385,9 @@ class CloudPickleTest(unittest.TestCase):
 
         assert ClonedColor.__doc__ == Color.__doc__
         assert ClonedColor.__module__ == Color.__module__
-        assert ClonedColor.__qualname__ == Color.__qualname__
+
+        if hasattr(Color, "__qualname__"):
+            assert ClonedColor.__qualname__ == Color.__qualname__
 
         # cloudpickle systematically creates new copies for locally defined
         # classes that cannot be imported by name:

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1368,6 +1368,30 @@ class CloudPickleTest(unittest.TestCase):
         pickle_depickle(DataClass, protocol=self.protocol)
         assert data.x == pickle_depickle(data, protocol=self.protocol).x == 42
 
+    def test_dynamically_defined_enum(self):
+        enum = pytest.importorskip("enum")
+
+        class Color(enum.Enum):
+            """3-element color space"""
+            RED = 1
+            GREEN = 2
+            BLUE = 3
+
+        green1, green2, ClonedColor = pickle_depickle(
+            [Color.GREEN, Color.GREEN, Color], protocol=self.protocol)
+        assert green1 is green2
+        assert green1 is ClonedColor.GREEN
+        assert green1 is not ClonedColor.BLUE
+
+        assert ClonedColor.__doc__ == Color.__doc__
+        assert ClonedColor.__module__ == Color.__module__
+        assert ClonedColor.__qualname__ == Color.__qualname__
+
+        # cloudpickle systematically creates new copies for locally defined
+        # classes that cannot be imported by name:
+        assert green1 is not Color.GREEN
+        assert ClonedColor is not Color
+
 
 class Protocol2CloudPickleTest(CloudPickleTest):
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -21,7 +21,6 @@ import types
 import unittest
 import weakref
 import os
-from enum import Enum, IntEnum
 
 import pytest
 
@@ -1468,8 +1467,9 @@ class CloudPickleTest(unittest.TestCase):
         assert data.x == pickle_depickle(data, protocol=self.protocol).x == 42
 
     def test_locally_defined_enum(self):
+        enum = pytest.importorskip("enum")
 
-        class Color(Enum):
+        class Color(enum.Enum):
             """3-element color space"""
             RED = 1
             GREEN = 2
@@ -1490,8 +1490,9 @@ class CloudPickleTest(unittest.TestCase):
         assert green3 is Color.GREEN
 
     def test_locally_defined_intenum(self):
+        enum = pytest.importorskip("enum")
         # Try again with a IntEnum defined with the functional API
-        DynamicColor = IntEnum("Color", {"RED": 1, "GREEN": 2, "BLUE": 3})
+        DynamicColor = enum.IntEnum("Color", {"RED": 1, "GREEN": 2, "BLUE": 3})
 
         green1, green2, ClonedDynamicColor = pickle_depickle(
             [DynamicColor.GREEN, DynamicColor.GREEN, DynamicColor],
@@ -1503,6 +1504,7 @@ class CloudPickleTest(unittest.TestCase):
         assert ClonedDynamicColor is DynamicColor
 
     def test_interactively_defined_enum(self):
+        pytest.importorskip("enum")
         code = """if __name__ == "__main__":
         from enum import Enum
         from testutils import subprocess_worker

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -21,6 +21,7 @@ import types
 import unittest
 import weakref
 import os
+from enum import Enum
 
 import pytest
 
@@ -1369,9 +1370,8 @@ class CloudPickleTest(unittest.TestCase):
         assert data.x == pickle_depickle(data, protocol=self.protocol).x == 42
 
     def test_dynamically_defined_enum(self):
-        enum = pytest.importorskip("enum")
 
-        class Color(enum.Enum):
+        class Color(Enum):
             """3-element color space"""
             RED = 1
             GREEN = 2

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1214,7 +1214,7 @@ class CloudPickleTest(unittest.TestCase):
             assert returned_counter.count == 2, returned_counter.count
 
             # Check that the class definition of the returned instance was
-            # matched back to the original class defintion living in __main__
+            # matched back to the original class definition living in __main__.
 
             assert isinstance(returned_counter, CustomCounter)
 
@@ -1246,7 +1246,7 @@ class CloudPickleTest(unittest.TestCase):
         with subprocess_worker(protocol={protocol}) as w:
 
             class A:
-                '''Original class defintion'''
+                '''Original class definition'''
                 pass
 
             def store(x):
@@ -1262,29 +1262,30 @@ class CloudPickleTest(unittest.TestCase):
 
             id1 = w.run(store, A())
 
-            # The stored object on the worker is matched to the class
-            # definition singleton thanks to provenance tracking:
+            # The stored object on the worker is matched to a singleton class
+            # definition thanks to provenance tracking:
             assert w.run(lambda obj_id: isinstance(lookup(obj_id), A), id1)
 
             # Retrieving the object from the worker yields a local copy that
-            # is matched back the local class definition this instance stems
-            # from.
+            # is matched back the local class definition this instance
+            # originally stems from.
             assert isinstance(w.run(lookup, id1), A)
 
-            # Changing the local class definitions should be reflected in
-            # all subsequent calls. In particular the old instances do not
-            # map back to the new class definition, neither locally, nor on the
-            # worker:
+            # Changing the local class definition should be taken into account
+            # in all subsequent calls. In particular the old instances on the
+            # worker do not map back to the new class definition, neither on
+            # the worker itself, nor locally on the main program when the old
+            # instance is retrieved:
 
             class A:
-                '''Modified class defintion'''
+                '''Updated class definition'''
                 pass
 
             assert not w.run(lambda obj_id: isinstance(lookup(obj_id), A), id1)
             retrieved1 = w.run(lookup, id1)
             assert not isinstance(retrieved1, A)
             assert retrieved1.__class__ is not A
-            assert retrieved1.__class__.__doc__ == "Original class defintion"
+            assert retrieved1.__class__.__doc__ == "Original class definition"
 
             # New instances on the other hand are proper instances of the new
             # class definition everywhere:
@@ -1324,9 +1325,10 @@ class CloudPickleTest(unittest.TestCase):
             import gc
             w.run(gc.collect)
 
-            # By this time the worker process has processed worth of 100MB of
-            # data passed in the closures its memory size should now have
-            # grown by more than a few MB.
+            # By this time the worker process has processed 100MB worth of data
+            # passed in the closures. The worker memory size should not have
+            # grown by more than a few MB as closures are garbage collected at
+            # the end of each remote function call.
             growth = w.memsize() - reference_size
             assert growth < 1e7, growth
 
@@ -1525,7 +1527,7 @@ class CloudPickleTest(unittest.TestCase):
 
             assert result is Color.GREEN
 
-            # Check that changing the defintion of the Enum class is taken
+            # Check that changing the definition of the Enum class is taken
             # into account on the worker for subsequent calls:
 
             class Color(Enum):

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1408,7 +1408,7 @@ class CloudPickleTest(unittest.TestCase):
         assert ClonedDynamicColor.__doc__ == DynamicColor.__doc__
 
     def test_interactively_defined_enum(self):
-        code = """if True:
+        code = """if __name__ == "__main__":
         from enum import Enum
         from testutils import subprocess_worker
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1486,7 +1486,10 @@ class CloudPickleTest(unittest.TestCase):
     def test_locally_defined_enum(self):
         enum = pytest.importorskip("enum")
 
-        class Color(str, enum.Enum):
+        class StringEnum(str, enum.Enum):
+            """Enum when all members are also (and must be) strings"""
+
+        class Color(StringEnum):
             """3-element color space"""
             RED = "1"
             GREEN = "2"

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -74,10 +74,12 @@ def _escape(raw_filepath):
 
 def test_extract_class_dict():
     class A(int):
+        """A docstring"""
         def method(self):
             return "a"
 
     class B:
+        """B docstring"""
         B_CONSTANT = 42
 
         def method(self):
@@ -90,8 +92,9 @@ def test_extract_class_dict():
             return "c"
 
     clsdict = _extract_class_dict(C)
-    assert sorted(clsdict.keys()) == ["C_CONSTANT", "method_c"]
+    assert sorted(clsdict.keys()) == ["C_CONSTANT", "__doc__", "method_c"]
     assert clsdict["C_CONSTANT"] == 43
+    assert clsdict["__doc__"] is None
     assert clsdict["method_c"](C()) == C().method_c()
 
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1486,20 +1486,25 @@ class CloudPickleTest(unittest.TestCase):
     def test_locally_defined_enum(self):
         enum = pytest.importorskip("enum")
 
-        class Color(enum.Enum):
+        class Color(str, enum.Enum):
             """3-element color space"""
-            RED = 1
-            GREEN = 2
-            BLUE = 3
+            RED = "1"
+            GREEN = "2"
+            BLUE = "3"
+
+            def is_green(self):
+                return self is Color.GREEN
 
         green1, green2, ClonedColor = pickle_depickle(
             [Color.GREEN, Color.GREEN, Color], protocol=self.protocol)
         assert green1 is green2
         assert green1 is ClonedColor.GREEN
         assert green1 is not ClonedColor.BLUE
+        assert isinstance(green1, str)
+        assert green1.is_green()
 
-        # cloudpickle systematically tracks procenance of class definitions
-        # and ensure reconcylation in case of round trips:
+        # cloudpickle systematically tracks provenance of class definitions
+        # and ensure reconciliation in case of round trips:
         assert green1 is Color.GREEN
         assert ClonedColor is Color
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1216,7 +1216,20 @@ class CloudPickleTest(unittest.TestCase):
 
             # Check that the class definition of the returned instance was
             # matched back to the original class defintion living in __main__
+
             assert isinstance(returned_counter, CustomCounter)
+
+            # Check that memoization does not break provenance tracking:
+
+            def echo(*args):
+                return args
+
+            C1, C2, c1, c2 = w.run(echo, CustomCounter, CustomCounter,
+                                   CustomCounter(), returned_counter)
+            assert C1 is CustomCounter
+            assert C2 is CustomCounter
+            assert isinstance(c1, CustomCounter)
+            assert isinstance(c2, CustomCounter)
 
         """.format(protocol=self.protocol)
         assert_run_python_script(code)
@@ -1476,6 +1489,7 @@ class CloudPickleTest(unittest.TestCase):
         green3 = pickle_depickle(Color.GREEN, protocol=self.protocol)
         assert green3 is Color.GREEN
 
+    def test_locally_defined_intenum(self):
         # Try again with a IntEnum defined with the functional API
         DynamicColor = IntEnum("Color", {"RED": 1, "GREEN": 2, "BLUE": 3})
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -21,7 +21,7 @@ import types
 import unittest
 import weakref
 import os
-from enum import Enum
+from enum import Enum, IntEnum
 
 import pytest
 
@@ -1393,6 +1393,19 @@ class CloudPickleTest(unittest.TestCase):
         # classes that cannot be imported by name:
         assert green1 is not Color.GREEN
         assert ClonedColor is not Color
+
+        # Try again with a IntEnum defined with the functional API
+        DynamicColor = IntEnum("Color", {"RED": 1, "GREEN": 2, "BLUE": 3})
+
+        green1, green2, ClonedDynamicColor = pickle_depickle(
+            [DynamicColor.GREEN, DynamicColor.GREEN, DynamicColor],
+            protocol=self.protocol)
+
+        assert green1 is green2
+        assert green1 is ClonedDynamicColor.GREEN
+        assert green1 is not ClonedDynamicColor.BLUE
+        assert ClonedDynamicColor.__module__ == DynamicColor.__module__
+        assert ClonedDynamicColor.__doc__ == DynamicColor.__doc__
 
 
 class Protocol2CloudPickleTest(CloudPickleTest):


### PR DESCRIPTION
This is a fix for #244 (and #101) to add support for dynamically defined Enum subclasses.

Properly adding support for dynamic Enums required to more broadly fix the `isinstance` semantics as initially requested in #195.

The proposed solution involves tracking the provenance of pickled dynamic class definitions with a pair of `weakref.WeakKeyDictionary` / `weakref.WeakValueDictionary` protected by a `threading.Lock`.