### PR TITLE
Test Python subprocess function calls

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,5 +2,7 @@
 flake8
 pytest
 pytest-cov
+psutil
+futures; python_version < '3.4'
 # Code coverage uploader for Travis:
 codecov

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1209,16 +1209,19 @@ class CloudPickleTest(unittest.TestCase):
             reference_size = w.memsize()
             assert reference_size > 0
 
+
             def make_big_closure(i):
                 # Generate a byte string of size 1MB
-                data = struct.pack("l", i) * (int(1e6) // 8)
+                itemsize = len(struct.pack("l", 1))
+                data = struct.pack("l", i) * (int(1e6) // itemsize)
                 def process_data():
                     return len(data)
                 return process_data
 
             for i in range(100):
                 func = make_big_closure(i)
-                assert w.run(func) == int(1e6)
+                result = w.run(func)
+                assert result == int(1e6), result
 
             import gc
             w.run(gc.collect)

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1125,7 +1125,7 @@ class CloudPickleTest(unittest.TestCase):
             _TEST_GLOBAL_VARIABLE = orig_value
 
     def test_interactive_remote_function_calls(self):
-        code = """if True:
+        code = """if __name__ == "__main__":
         from testutils import subprocess_worker
 
         def interactive_function(x):
@@ -1154,22 +1154,22 @@ class CloudPickleTest(unittest.TestCase):
         assert_run_python_script(code)
 
     def test_interactive_remote_function_calls_side_effects(self):
-        code = """if True:
+        code = """if __name__ == "__main__":
         from testutils import subprocess_worker
         import sys
 
-        GLOBAL_VARIABLE = 0
-
-        class CustomClass(object):
-
-            def mutate_globals(self):
-                global GLOBAL_VARIABLE
-                GLOBAL_VARIABLE += 1
-                return GLOBAL_VARIABLE
-
-        custom_object = CustomClass()
-
         with subprocess_worker(protocol={protocol}) as w:
+
+            GLOBAL_VARIABLE = 0
+
+            class CustomClass(object):
+
+                def mutate_globals(self):
+                    global GLOBAL_VARIABLE
+                    GLOBAL_VARIABLE += 1
+                    return GLOBAL_VARIABLE
+
+            custom_object = CustomClass()
 
             custom_object
             assert w.run(custom_object.mutate_globals) == 1
@@ -1190,8 +1190,7 @@ class CloudPickleTest(unittest.TestCase):
 
             assert is_in_main("CustomClass")
 
-            # XXX: Is the following a bug or not?
-            # assert not w.run(is_in_main, "CustomClass")
+            assert not w.run(is_in_main, "CustomClass")
 
         """.format(protocol=self.protocol)
         assert_run_python_script(code)

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1216,12 +1216,16 @@ class CloudPickleTest(unittest.TestCase):
 
             for i in range(100):
                 func = make_big_closure(i)
-                assert w.run(func) == int(1e6) // 8
+                assert w.run(func) == int(1e6)
+
+            import gc
+            w.run(gc.collect)
 
             # By this time the worker process has processed worth of 100MB of
             # data passed in the closures its memory size should now have
             # grown by more than a few MB.
-            assert w.memsize() - reference_size < 1e7
+            growth = w.memsize() - reference_size
+            assert growth < 1e7, growth
 
         """.format(protocol=self.protocol)
         assert_run_python_script(code)

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1197,6 +1197,8 @@ class CloudPickleTest(unittest.TestCase):
         """.format(protocol=self.protocol)
         assert_run_python_script(code)
 
+    @pytest.mark.skipif(platform.python_implementation() == 'PyPy',
+                        reason="Skip PyPy because memory grows too much")
     def test_interactive_remote_function_calls_no_memory_leak(self):
         code = """if __name__ == "__main__":
         from testutils import subprocess_worker

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -4,8 +4,12 @@ import os.path as op
 import tempfile
 import base64
 from subprocess import Popen, check_output, PIPE, STDOUT, CalledProcessError
-from cloudpickle import dumps
 from pickle import loads
+from contextlib import contextmanager
+from concurrent.futures import ProcessPoolExecutor
+
+import psutil
+from cloudpickle import dumps
 
 TIMEOUT = 60
 try:
@@ -42,6 +46,20 @@ def _make_cwd_env():
     return cloudpickle_repo_folder, env
 
 
+def _pack(input_data, protocol=None):
+    pickled_input_data = dumps(input_data, protocol=protocol)
+    # Under Windows + Python 2.7, subprocess / communicate truncate the data
+    # on some specific bytes. To avoid this issue, let's use the pure ASCII
+    # Base32 encoding to encapsulate the pickle message sent to the child
+    # process.
+    return base64.b32encode(pickled_input_data)
+
+
+def _unpack(packed_data):
+    decoded_data = base64.b32decode(packed_data)
+    return loads(decoded_data)
+
+
 def subprocess_pickle_echo(input_data, protocol=None, timeout=TIMEOUT):
     """Echo function with a child Python process
 
@@ -53,18 +71,12 @@ def subprocess_pickle_echo(input_data, protocol=None, timeout=TIMEOUT):
     [1, 'a', None]
 
     """
-    pickled_input_data = dumps(input_data, protocol=protocol)
-    # Under Windows + Python 2.7, subprocess / communicate truncate the data
-    # on some specific bytes. To avoid this issue, let's use the pure ASCII
-    # Base32 encoding to encapsulate the pickle message sent to the child
-    # process.
-    pickled_b32 = base64.b32encode(pickled_input_data)
-
     # run then pickle_echo(protocol=protocol) in __main__:
     cmd = [sys.executable, __file__, "--protocol", str(protocol)]
     cwd, env = _make_cwd_env()
     proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, cwd=cwd, env=env,
                  bufsize=4096)
+    pickled_b32 = _pack(input_data, protocol=protocol)
     try:
         comm_kwargs = {}
         if timeout_supported:
@@ -74,12 +86,24 @@ def subprocess_pickle_echo(input_data, protocol=None, timeout=TIMEOUT):
             message = "Subprocess returned %d: " % proc.returncode
             message += err.decode('utf-8')
             raise RuntimeError(message)
-        return loads(base64.b32decode(out))
+        return _unpack(out)
     except TimeoutExpired:
         proc.kill()
         out, err = proc.communicate()
         message = u"\n".join([out.decode('utf-8'), err.decode('utf-8')])
         raise RuntimeError(message)
+
+
+def _read_bytes(stream_in, size):
+    all_data = b""
+    remaining = size
+    while True:
+        data = stream_in.read(remaining)
+        all_data += data
+        remaining -= len(data)
+        if remaining == 0:
+            break
+    return all_data
 
 
 def _read_all_bytes(stream_in, chunk_size=4096):
@@ -111,6 +135,55 @@ def pickle_echo(stream_in=None, stream_out=None, protocol=None):
     repickled_bytes = dumps(obj, protocol=protocol)
     stream_out.write(base64.b32encode(repickled_bytes))
     stream_out.close()
+
+
+def call_func(payload, protocol):
+    """Remote function call that uses cloudpickle to transport everthing"""
+    func, args, kwargs = _unpack(payload)
+    try:
+        result = func(*args, **kwargs)
+    except BaseException as e:
+        result = e
+    return _pack(result, protocol=protocol)
+
+
+class _Worker(object):
+    def __init__(self, protocol=None):
+        self.protocol = protocol
+        self.pool = ProcessPoolExecutor(max_workers=1)
+        self.pool.submit(id, 42).result()  # start the worker
+
+    def run(self, func, *args, **kwargs):
+        """Synchronous remote function call"""
+
+        input_payload = _pack((func, args, kwargs), protocol=self.protocol)
+        result_payload = self.pool.submit(
+            call_func, input_payload, self.protocol).result()
+        result = _unpack(result_payload)
+
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    def memsize(self):
+        workers_pids = list(self.pool._processes.keys())
+        num_workers = len(workers_pids)
+        if num_workers == 0:
+            return 0
+        elif num_workers > 1:
+            raise RuntimeError("Unexpected number of workers: %d"
+                               % num_workers)
+        return psutil.Process(workers_pids[0]).memory_info().rss
+
+    def close(self):
+        self.pool.shutdown(wait=True)
+
+
+@contextmanager
+def subprocess_worker(protocol=None):
+    worker = _Worker(protocol=protocol)
+    yield worker
+    worker.close()
 
 
 def assert_run_python_script(source_code, timeout=TIMEOUT):

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -154,7 +154,8 @@ class _Worker(object):
         return result
 
     def memsize(self):
-        workers_pids = list(self.pool._processes.keys())
+        workers_pids = [p.pid if hasattr(p, "pid") else p
+                        for p in list(self.pool._processes)]
         num_workers = len(workers_pids)
         if num_workers == 0:
             return 0


### PR DESCRIPTION
Here is a new test helper to be able to write tests that checks the cloudpickle semantics in the context of remote procedure calls.

This is basically a single-worker, single-host simplified version of what can be provided by downstream projects such as PySpark, dask and ray.

See also the discussion in https://github.com/cloudpipe/cloudpickle/pull/246/files#r255429887 and  #195.