### PR TITLE
ENH: derive from C-pickler for fast serialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,8 +91,13 @@ install:
   - $PYTHON_EXE -m pip install .
   - $PYTHON_EXE -m pip install --upgrade -r dev-requirements.txt
   - $PYTHON_EXE -m pip install tornado
-  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* && "$PYTHON_NIGHTLY" != 1 ]]; then
+  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
+      if [[ "$PYTHON_NIGHTLY" == 1 ]]; then
+        # Install the master version of numpy (with the master branch of cython)
+        $PYTHON_EXE -m pip install git+https://github.com/cython/cython git+https://github.com/numpy/numpy;
+      else
         $PYTHON_EXE -m pip install numpy scipy;
+      fi
     fi
   - if [[ $PROJECT != "" ]]; then
         $PYTHON_EXE -m pip install $TEST_REQUIREMENTS;

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
     - os: linux
       if: commit_message =~ /(\[ci python-nightly\])/
       env: PYTHON_NIGHTLY=1
+      python: 3.7
     - os: linux
       python: 3.7
     - os: linux
@@ -137,5 +138,5 @@ script:
       fi
     fi
 after_success:
-  - $PYTHON_EXE -m coverage combine --append
-  - $PYTHON_EXE -m codecov
+  - coverage combine --append
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ install:
   - $PYTHON_EXE -m pip install --upgrade -r dev-requirements.txt
   - $PYTHON_EXE -m pip install tornado
   - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
-      if [[ "$PYTHON_NIGHTLY" == 1 ]]; then
+      if [[ "$PYTHON_NIGHTLY" == "1" ]]; then
         # Install the master version of numpy (with the master branch of cython)
         $PYTHON_EXE -m pip install git+https://github.com/cython/cython git+https://github.com/numpy/numpy;
       else

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,5 +137,5 @@ script:
       fi
     fi
 after_success:
-  - coverage combine --append
-  - codecov
+  - $PYTHON_EXE -m coverage combine --append
+  - $PYTHON_EXE -m codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,23 @@ dist: xenial
 
 matrix:
   include:
-    - os: windows
-      language: sh
-      env: PYTHON_ROOT="/c/Python37" PYTHON_CHOCO_PKG="python3"
-    - os: windows
-      language: sh
-      env: PYTHON_ROOT="/c/Python27" PYTHON_CHOCO_PKG="python2"
+    # - os: windows
+    #   language: sh
+    #   env: PYTHON_ROOT="/c/Python37" PYTHON_CHOCO_PKG="python3"
+    # - os: windows
+    #   language: sh
+    #   env: PYTHON_ROOT="/c/Python27" PYTHON_CHOCO_PKG="python2"
+    # - os: linux
+    #   dist: trusty
+    #   python: "pypy3"
+    # - os: linux
+    #   python: 3.7
+    # - os: linux
+    #   python: 3.6
+    # - os: linux
+    #   python: 3.5
+    # - os: linux
+    #   python: 2.7
     - os: linux
       dist: trusty
       python: "pypy3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
     - os: linux
       python: 3.7
     - os: linux
+      python: 3.8-dev
+    - os: linux
       python: 3.6
     - os: linux
       python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,12 @@ dist: xenial
 
 matrix:
   include:
-    # - os: windows
-    #   language: sh
-    #   env: PYTHON_ROOT="/c/Python37" PYTHON_CHOCO_PKG="python3"
-    # - os: windows
-    #   language: sh
-    #   env: PYTHON_ROOT="/c/Python27" PYTHON_CHOCO_PKG="python2"
-    # - os: linux
-    #   dist: trusty
-    #   python: "pypy3"
-    # - os: linux
-    #   python: 3.7
-    # - os: linux
-    #   python: 3.6
-    # - os: linux
-    #   python: 3.5
-    # - os: linux
-    #   python: 2.7
+    - os: windows
+      language: sh
+      env: PYTHON_ROOT="/c/Python37" PYTHON_CHOCO_PKG="python3"
+    - os: windows
+      language: sh
+      env: PYTHON_ROOT="/c/Python27" PYTHON_CHOCO_PKG="python2"
     - os: linux
       dist: trusty
       python: "pypy3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,5 +138,6 @@ script:
       fi
     fi
 after_success:
+  - pip install coverage codecov
   - coverage combine --append
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,12 +92,11 @@ install:
   - $PYTHON_EXE -m pip install --upgrade -r dev-requirements.txt
   - $PYTHON_EXE -m pip install tornado
   - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
-      if [[ "$PYTHON_NIGHTLY" == "1" ]]; then
-        # Install the master version of numpy (with the master branch of cython)
-        $PYTHON_EXE -m pip install git+https://github.com/cython/cython git+https://github.com/numpy/numpy;
-      else
-        $PYTHON_EXE -m pip install numpy scipy;
-      fi
+        if [[ "$PYTHON_NIGHTLY" == "1" ]]; then
+          $PYTHON_EXE -m pip install git+https://github.com/cython/cython git+https://github.com/numpy/numpy;
+        else
+          $PYTHON_EXE -m pip install numpy scipy;
+        fi
     fi
   - if [[ $PROJECT != "" ]]; then
         $PYTHON_EXE -m pip install $TEST_REQUIREMENTS;

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,10 @@ matrix:
       dist: trusty
       python: "pypy3"
     - os: linux
-      if: commit_message =~ /(\[ci python-nightly\])/
       env: PYTHON_NIGHTLY=1
       python: 3.7
     - os: linux
       python: 3.7
-    - os: linux
-      python: 3.8-dev
     - os: linux
       python: 3.6
     - os: linux

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 1.2.0
 =====
 
+- Leverage the C-accelerated Pickler new subclassing API (available in Python
+  3.8) in cloudpickle. This allows cloudpickle to pickle Python objects up to
+  30 times faster.
+  ([issue #253](https://github.com/cloudpipe/cloudpickle/pull/253))
+
 - Support pickling of classmethod and staticmethod objects in python2.
   arguments. ([issue #262](https://github.com/cloudpipe/cloudpickle/pull/262))
 

--- a/cloudpickle/__init__.py
+++ b/cloudpickle/__init__.py
@@ -4,9 +4,8 @@ import sys
 import pickle
 
 
+from cloudpickle.cloudpickle import *
 if sys.version_info[:2] >= (3, 8):
-    from cloudpickle.cloudpickle_fast import *
-else:
-    from cloudpickle.cloudpickle import *
+    from cloudpickle.cloudpickle_fast import CloudPickler, dumps, dump
 
 __version__ = '1.2.0.dev0'

--- a/cloudpickle/__init__.py
+++ b/cloudpickle/__init__.py
@@ -4,7 +4,7 @@ import sys
 import pickle
 
 
-if hasattr(pickle.Pickler, 'global_hook'):
+if hasattr(pickle.Pickler, 'reducer_override'):
     from cloudpickle.cloudpickle_fast import *
 else:
     from cloudpickle.cloudpickle import *

--- a/cloudpickle/__init__.py
+++ b/cloudpickle/__init__.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import
 
 import sys
+import pickle
 
 
-if sys.version_info[:2] >= (3, 8):
+if hasattr(pickle.Pickler, 'global_hook'):
     from cloudpickle.cloudpickle_fast import *
 else:
     from cloudpickle.cloudpickle import *

--- a/cloudpickle/__init__.py
+++ b/cloudpickle/__init__.py
@@ -4,7 +4,7 @@ import sys
 import pickle
 
 
-if hasattr(pickle.Pickler, 'reducer_override'):
+if sys.version_info[:2] >= (3, 8):
     from cloudpickle.cloudpickle_fast import *
 else:
     from cloudpickle.cloudpickle import *

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -222,7 +222,7 @@ def _extract_code_globals(co):
     return out_names
 
 
-def _find_loaded_submodules(code, top_level_dependencies):
+def _find_imported_submodules(code, top_level_dependencies):
     """
     Save submodules used by a function but not listed in its globals.
     In the example below:
@@ -744,7 +744,7 @@ class CloudPickler(Pickler):
         save(_fill_function)  # skeleton function updater
         write(pickle.MARK)    # beginning of tuple that _fill_function expects
 
-        submodules = _find_loaded_submodules(
+        submodules = _find_imported_submodules(
             code,
             itertools.chain(f_globals.values(), closure_values or ()),
         )

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -679,8 +679,8 @@ class CloudPickler(Pickler):
         # If type overrides __dict__ as a property, include it in the type
         # kwargs. In Python 2, we can't set this attribute after construction.
         __dict__ = clsdict.pop('__dict__', None)
-        # if isinstance(__dict__, property):
-        #     type_kwargs['__dict__'] = __dict__
+        if isinstance(__dict__, property):
+            type_kwargs['__dict__'] = __dict__
 
         save = self.save
         write = self.write

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -752,7 +752,7 @@ class CloudPickler(Pickler):
         code = func.__code__
 
         # extract all global ref's
-        func_global_refs = extract_code_globals(code)
+        func_global_refs = _extract_code_globals(code)
 
         # process all variables referenced by global environment
         f_globals = {}

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -681,11 +681,11 @@ class CloudPickler(Pickler):
         save(_fill_function)  # skeleton function updater
         write(pickle.MARK)    # beginning of tuple that _fill_function expects
 
-        subimports = _find_loaded_submodules(
+        submodules = _find_loaded_submodules(
             code,
             itertools.chain(f_globals.values(), closure_values or ()),
         )
-        for s in subimports:
+        for s in submodules:
             # ensure that subimport s is loaded at unpickling time
             self.save(s)
             # then discards the reference to it

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -102,6 +102,15 @@ else:
     PY2 = False
     from importlib._bootstrap import _find_spec
 
+# XXX: This cache cannot be a WeakKeyDictionary, because sometimes, cloudpickle
+# misclassifies a builtin pypy function as dynamic, and thus tries to extract
+# the globals of its underlying builtin-code. However, builtin-code objects
+# cannot be weak-referenced (hence the if-else clause below).
+# Note that the root cause of cloudpickle misclassification of builtin
+# functions is PyPy flaky support of __qualname__ attributes in v3.5. This
+# guard can be removed by either spotting more proactively builtin pypy
+# functions before trying to save them as dynamic, or simply after support for
+# pypy3.5 is dropped.
 _extract_code_globals_cache = (
     weakref.WeakKeyDictionary()
     if not hasattr(sys, "pypy_version_info")

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -679,8 +679,8 @@ class CloudPickler(Pickler):
         # If type overrides __dict__ as a property, include it in the type
         # kwargs. In Python 2, we can't set this attribute after construction.
         __dict__ = clsdict.pop('__dict__', None)
-        if isinstance(__dict__, property):
-            type_kwargs['__dict__'] = __dict__
+        # if isinstance(__dict__, property):
+        #     type_kwargs['__dict__'] = __dict__
 
         save = self.save
         write = self.write

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -102,11 +102,6 @@ else:
     PY2 = False
     from importlib._bootstrap import _find_spec
 
-    if platform.python_implementation() == 'PyPy':
-        from importlib._bootstrap import _find_spec
-    else:
-        from _frozen_importlib import _find_spec
-
 _extract_code_globals_cache = (
     weakref.WeakKeyDictionary()
     if not hasattr(sys, "pypy_version_info")
@@ -194,8 +189,8 @@ def _is_global(obj, name=None):
         # supported, as the standard pickle does not support it either.
         return False
 
+    # module has been added to sys.modules, but it can still be dynamic.
     if _is_dynamic(module):
-        # module has been added to sys.modules, but it can still be dynamic.
         return False
 
     try:

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -18,7 +18,7 @@ import weakref
 from _pickle import Pickler
 
 from .cloudpickle import (
-    islambda, _is_dynamic, extract_code_globals, _BUILTIN_TYPE_CONSTRUCTORS,
+    islambda, _is_dynamic, _extract_code_globals, _BUILTIN_TYPE_CONSTRUCTORS,
     _BUILTIN_TYPE_NAMES, DEFAULT_PROTOCOL, _find_loaded_submodules,
     _get_cell_contents
 )
@@ -154,7 +154,7 @@ def _function_getstate(func):
         "__closure__": func.__closure__,
     }
 
-    f_globals_ref = extract_code_globals(func.__code__)
+    f_globals_ref = _extract_code_globals(func.__code__)
     f_globals = {k: func.__globals__[k] for k in f_globals_ref if k in
                  func.__globals__}
 

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -475,8 +475,7 @@ class CloudPickler(Pickler):
     # function reducers are defined as instance methods of CloudPickler
     # objects, as they rely on a CloudPickler attribute (globals_ref)
     def _dynamic_function_reduce(self, func):
-        """Reduce a function that is not pickleable via attribute lookup.
-        """
+        """Reduce a function that is not pickleable via attribute lookup."""
         newargs = self._function_getnewargs(func)
         state = _function_getstate(func)
         return (types.FunctionType, newargs, state, None, None,

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -359,7 +359,7 @@ def _function_reduce(obj, globals_ref):
     if lookedup_by_name is obj:  # in this case, module is None
         # if obj exists in a filesytem-backed module, let the builtin pickle
         # saving routines save obj
-        return NotImplementedError
+        return NotImplemented
 
     # XXX: the special handling of builtin_function_or_method is removed as
     # currently this hook is not called for such instances, as opposed to
@@ -376,7 +376,7 @@ def _function_reduce(obj, globals_ref):
         return _dynamic_function_reduce(obj, globals_ref=globals_ref)
 
     # this whole code section may be cleanable: the if/else conditions + the
-    # NotImplementedError look like they cover nearly all cases.
+    # NotImplemented look like they cover nearly all cases.
     else:
         # func is nested
         if lookedup_by_name is None or lookedup_by_name is not obj:
@@ -463,7 +463,7 @@ def _class_reduce(obj):
         # if pickle.dumps worked out fine, then simply fallback to the
         # traditional pickle by attribute # implemented in the builtin
         # `Pickler.save_global`.
-        return NotImplementedError
+        return NotImplemented
 
 
 # COLLECTIONS OF OBJECTS STATE SETTERS
@@ -539,7 +539,7 @@ def _reduce_global(pickler, obj):
         return _function_reduce(obj, pickler.globals_ref)
     else:
         # fallback to save_global, including the pickler's distpatch_table
-        return NotImplementedError
+        return NotImplemented
 
 
 class CloudPickler(Pickler):
@@ -585,10 +585,10 @@ class CloudPickler(Pickler):
         # will likely not be known in advance, and thus cannot be special-cased
         # using an entry in the dispatch_table.
 
-        # The pickler's global_hook, among other things, allows us to register
-        # a reducer that will be called for any class, independently of its
-        # type.
-        self.global_hook = _reduce_global
+        # The pickler's reducer_override, among other things, allows us to
+        # register a reducer that will be called for any class, independently
+        # of its type.
+        self.reducer_override = _reduce_global
         self.proto = int(protocol)
 
     def dump(self, obj):

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -6,11 +6,9 @@ previous pythonic Pickler. Because this functionality is only available for
 python versions 3.8+, a lot of backward-compatibilty code is also removed.
 """
 import abc
-import dis
 import io
 import itertools
 import logging
-import opcode
 import _pickle
 import pickle
 import sys
@@ -20,9 +18,9 @@ import weakref
 from _pickle import Pickler
 
 from .cloudpickle import (
-    islambda, _is_dynamic, extract_code_globals, GLOBAL_OPS,
-    _BUILTIN_TYPE_CONSTRUCTORS, _BUILTIN_TYPE_NAMES, DEFAULT_PROTOCOL,
-    _find_loaded_submodules, _get_cell_contents
+    islambda, _is_dynamic, extract_code_globals, _BUILTIN_TYPE_CONSTRUCTORS,
+    _BUILTIN_TYPE_NAMES, DEFAULT_PROTOCOL, _find_loaded_submodules,
+    _get_cell_contents
 )
 
 load, loads = _pickle.load, _pickle.loads

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -188,23 +188,14 @@ def _enum_getstate(obj):
 
 def _code_reduce(obj):
     """codeobject reducer"""
-    if hasattr(obj, "co_posonlyargcount"):  # pragma: no branch
-        args = (
-            obj.co_argcount, obj.co_posonlyargcount,
-            obj.co_kwonlyargcount, obj.co_nlocals, obj.co_stacksize,
-            obj.co_flags, obj.co_code, obj.co_consts, obj.co_names,
-            obj.co_varnames, obj.co_filename, obj.co_name,
-            obj.co_firstlineno, obj.co_lnotab, obj.co_freevars,
-            obj.co_cellvars
-        )
-    else:
-        args = (
-            obj.co_argcount, obj.co_kwonlyargcount, obj.co_nlocals,
-            obj.co_stacksize, obj.co_flags, obj.co_code, obj.co_consts,
-            obj.co_names, obj.co_varnames, obj.co_filename,
-            obj.co_name, obj.co_firstlineno, obj.co_lnotab,
-            obj.co_freevars, obj.co_cellvars
-        )
+    args = (
+        obj.co_argcount, obj.co_posonlyargcount,
+        obj.co_kwonlyargcount, obj.co_nlocals, obj.co_stacksize,
+        obj.co_flags, obj.co_code, obj.co_consts, obj.co_names,
+        obj.co_varnames, obj.co_filename, obj.co_name,
+        obj.co_firstlineno, obj.co_lnotab, obj.co_freevars,
+        obj.co_cellvars
+    )
     return types.CodeType, args
 
 

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -51,14 +51,10 @@ def dumps(obj, protocol=None):
     Set protocol=pickle.DEFAULT_PROTOCOL instead if you need to ensure
     compatibility with older versions of Python.
     """
-    file = io.BytesIO()
-    try:
+    with io.BytesIO() as file:
         cp = CloudPickler(file, protocol=protocol)
         cp.dump(obj)
         return file.getvalue()
-    finally:
-        file.close()
-
 
 # COLLECTION OF OBJECTS __getnewargs__-LIKE METHODS
 # -------------------------------------------------

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -484,13 +484,14 @@ def _class_reduce(obj):
 # it has to be updated to how it was at unpickling time.
 
 
-def _function_setstate(obj, state, slotstate):
+def _function_setstate(obj, state):
     """Update the state of a dynaamic function.
 
     As __closure__ and __globals__ are readonly attributes of a function, we
     cannot rely on the native setstate routine of pickle.load_build, that calls
     setattr on items of the slotstate. Instead, we have to modify them inplace.
     """
+    state, slotstate = state
     obj.__dict__.update(state)
 
     obj_globals = slotstate.pop("__globals__")
@@ -513,7 +514,8 @@ def _function_setstate(obj, state, slotstate):
         setattr(obj, k, v)
 
 
-def _class_setstate(obj, state, slotstate):
+def _class_setstate(obj, state):
+    state, slotstate = state
     registry = None
     for attrname, attr in state.items():
         if attrname == "_abc_impl":

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -452,9 +452,9 @@ class CloudPickler(Pickler):
 
         Notes:
 
-        - reducer_override has the priority over dispatch_table-registered
+        * reducer_override has the priority over dispatch_table-registered
           reducers.
-        - reducer_override can be use to fix other limitations of cloudpickle
+        * reducer_override can be use to fix other limitations of cloudpickle
           for other types that suffered from type-specific reducers, such as
           Exceptions. See https://github.com/cloudpipe/cloudpickle/issues/248
         """

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -397,7 +397,7 @@ class CloudPickler(Pickler):
 
     * its dispatch_table containing reducers that are called only if ALL
       built-in saving functions were previously discarded.
-    * a special callback, invoked before standard function/class
+    * a special callback named "reducer_override", invoked before standard function/class
       builtin-saving method (save_global), to serialize dynamic functions
     """
 

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -469,7 +469,9 @@ def class_reduce(obj):
             return dynamic_class_reduce(obj)
 
     else:
-        # if pickle.dumps worked out fine, then simply pickle by attribute
+        # if pickle.dumps worked out fine, then simply fallback to the
+        # traditional pickle by attribute # implemented in the builtin
+        # `Pickler.save_global`.
         return NotImplementedError
 
 

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -485,9 +485,12 @@ class CloudPickler(Pickler):
         obj from an attribute lookup of a file-backed module. If this check
         fails, then a custom reducer is called.
         """
-        if not _is_global(obj):
+        # There no special handling for builtin pypy functions like in
+        # cloudpickle.py because cloudpickle_fast is CPython-specific.
+        if _is_global(obj):
+            return NotImplemented
+        else:
             return self._dynamic_function_reduce(obj)
-        return NotImplemented
 
     def _function_getnewargs(self, func):
         code = func.__code__

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -313,9 +313,6 @@ def _dynamic_class_reduce(obj):
 
 def _class_reduce(obj):
     """Select the reducer depending on the dynamic nature of the class obj"""
-    # XXX: there used to be special handling for NoneType, EllipsisType and
-    # NotImplementedType. As for now this module handles only python3.8+, this
-    # code has been removed.
     if obj is type(None):  # noqa
         return type, (None,)
     elif obj is type(Ellipsis):

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -451,7 +451,7 @@ class CloudPickler(Pickler):
 
         * reducer_override has the priority over dispatch_table-registered
           reducers.
-        * reducer_override can be use to fix other limitations of cloudpickle
+        * reducer_override can be used to fix other limitations of cloudpickle
           for other types that suffered from type-specific reducers, such as
           Exceptions. See https://github.com/cloudpipe/cloudpickle/issues/248
         """

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -82,6 +82,15 @@ def _function_getnewargs(func, globals_ref):
     # multiple invokations are bound to the same Cloudpickler.
     base_globals = globals_ref.setdefault(id(func.__globals__), {})
 
+    if base_globals == {}:
+        # Add module attributes used to resolve relative imports
+        # instructions inside func.
+        for k in ["__package__", "__name__", "__path__", "__file__"]:
+            # Some built-in functions/methods such as object.__new__  have
+            # their __globals__ set to None in PyPy
+            if func.__globals__ is not None and k in func.__globals__:
+                base_globals[k] = func.__globals__[k]
+
     # Do not bind the free variables before the function is created to avoid
     # infinite recursion.
     if func.__closure__ is None:

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -483,14 +483,17 @@ class CloudPickler(Pickler):
                 _function_setstate)
 
     def _function_reduce(self, obj):
-        """Select the reducer depending on obj's dynamic nature
+        """Reducer for function objects.
 
-        This functions starts by replicating save_global: trying to retrieve
-        obj from an attribute lookup of a file-backed module. If this check
-        fails, then a custom reducer is called.
+        If obj is a top-level attribute of a file-backed module, this
+        reducer returns NotImplemented, making the CloudPickler fallback to
+        traditional _pickle.Pickler routines to save obj. Otherwise, it reduces
+        obj using a custom cloudpickle reducer designed specifically to handle
+        dynamic functions.
+
+        As opposed to cloudpickle.py, There no special handling for builtin
+        pypy functions because cloudpickle_fast is CPython-specific.
         """
-        # There no special handling for builtin pypy functions like in
-        # cloudpickle.py because cloudpickle_fast is CPython-specific.
         if _is_global(obj):
             return NotImplemented
         else:

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -2,8 +2,8 @@
 New, fast version of the CloudPickler.
 
 This new CloudPickler class can now extend the fast C Pickler instead of the
-previous python implementation of the Pickler class. Because this functionality
-is only available for python versions 3.8+, a lot of backward-compatibility
+previous Python implementation of the Pickler class. Because this functionality
+is only available for Python versions 3.8+, a lot of backward-compatibility
 code is also removed.
 
 Note that the C Pickler sublassing API is CPython-specific. Therefore, some
@@ -26,12 +26,12 @@ from _pickle import Pickler
 from .cloudpickle import (
     _is_dynamic, _extract_code_globals, _BUILTIN_TYPE_NAMES, DEFAULT_PROTOCOL,
     _find_imported_submodules, _get_cell_contents, _is_global, _builtin_type,
-    Enum, _ensure_tracking, _lookup_class_or_track, _make_skeleton_class,
-    _make_skeleton_enum, _extract_class_dict, string_types, dynamic_subimport,
-    subimport
+    Enum, _ensure_tracking,  _make_skeleton_class, _make_skeleton_enum,
+    _extract_class_dict, string_types, dynamic_subimport, subimport
 )
 
 load, loads = _pickle.load, _pickle.loads
+
 
 # Shorthands similar to pickle.dump/pickle.dumps
 def dump(obj, file, protocol=None):
@@ -391,8 +391,9 @@ class CloudPickler(Pickler):
 
     * its dispatch_table containing reducers that are called only if ALL
       built-in saving functions were previously discarded.
-    * a special callback named "reducer_override", invoked before standard function/class
-      builtin-saving method (save_global), to serialize dynamic functions
+    * a special callback named "reducer_override", invoked before standard
+      function/class builtin-saving method (save_global), to serialize dynamic
+      functions
     """
 
     # cloudpickle's own dispatch_table, containing the additional set of

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -27,8 +27,6 @@ from .cloudpickle import (
 load, loads = _pickle.load, _pickle.loads
 
 # Shorthands similar to pickle.dump/pickle.dumps
-
-
 def dump(obj, file, protocol=None):
     """Serialize obj as bytes streamed into file
 
@@ -57,9 +55,9 @@ def dumps(obj, protocol=None):
         cp.dump(obj)
         return file.getvalue()
 
+
 # COLLECTION OF OBJECTS __getnewargs__-LIKE METHODS
 # -------------------------------------------------
-
 
 def _function_getnewargs(func, globals_ref):
     code = func.__code__

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -538,13 +538,12 @@ def _reduce_global(pickler, obj):
     save_reduce.
     """
     t = type(obj)
-
     try:
-        is_metaclass = issubclass(t, type)
+        is_anyclass = issubclass(t, type)
     except TypeError:  # t is not a class (old Boost; see SF #502085)
-        is_metaclass = False
+        is_anyclass = False
 
-    if is_metaclass:
+    if is_anyclass:
         return _class_reduce(obj)
     elif isinstance(obj, types.FunctionType):
         return _function_reduce(obj, pickler.globals_ref)

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -7,6 +7,7 @@ is only available for python versions 3.8+, a lot of backward-compatibility
 code is also removed.
 """
 import abc
+import copyreg
 import io
 import itertools
 import logging
@@ -400,7 +401,7 @@ class CloudPickler(Pickler):
       builtin-saving method (save_global), to serialize dynamic functions
     """
 
-    dispatch = {}
+    dispatch = copyreg.dispatch_table.copy()
     dispatch[classmethod] = _classmethod_reduce
     dispatch[io.TextIOWrapper] = _file_reduce
     dispatch[logging.Logger] = _logger_reduce

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -368,10 +368,7 @@ def classmethod_reduce(obj):
 
 def file_reduce(obj):
     """Save a file"""
-    try:
-        import StringIO as pystringIO  # we can't use cStringIO as it lacks the name attribute
-    except ImportError:
-        import io as pystringIO
+    import io
 
     if not hasattr(obj, "name") or not hasattr(obj, "mode"):
         raise pickle.PicklingError(
@@ -391,12 +388,13 @@ def file_reduce(obj):
         )
     if "r" not in obj.mode and "+" not in obj.mode:
         raise pickle.PicklingError(
-            "Cannot pickle files that are not opened for reading: %s" % obj.mode
+            "Cannot pickle files that are not opened for reading: %s"
+            % obj.mode
         )
 
     name = obj.name
 
-    retval = pystringIO.StringIO()
+    retval = io.StringIO()
 
     try:
         # Read the whole file

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -553,14 +553,14 @@ def _reduce_global(pickler, obj):
 
 
 class CloudPickler(Pickler):
-    """Fast C Pickler extension with additional reducing routines
+    """Fast C Pickler extension with additional reducing routines.
 
-       Cloudpickler's extensions exist into into:
+    Cloudpickler's extensions exist into into:
 
-       * it's dispatch_table containing reducers that are called only if ALL
-         built-in saving functions were previously discarded.
-       * a special callback, invoked before standard function/class
-         builtin-saving method (save_global), to serialize dynamic functions
+    * it's dispatch_table containing reducers that are called only if ALL
+      built-in saving functions were previously discarded.
+    * a special callback, invoked before standard function/class
+      builtin-saving method (save_global), to serialize dynamic functions
     """
 
     dispatch = {}

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -529,11 +529,6 @@ def _class_setstate(obj, state):
     return obj
 
 
-# Arbitration between builtin-save method and user-defined callbacks
-# ------------------------------------------------------------------
-# This set of functions aim at deciding whether an object can be properly
-# pickler by the c Pickler, or if it needs to be serialized using cloudpickle's
-# reducers.
 def _reduce_global(pickler, obj):
     """Custom reducing callback for functions and classes
 
@@ -542,13 +537,6 @@ def _reduce_global(pickler, obj):
     we return a reduce value the the Pickler will internally serialize via
     save_reduce.
     """
-    # Classes deriving from custom, dynamic metaclasses won't get caught inside
-    # the hook_dispatch dict. In the legacy cloudpickle, this was not really a
-    # problem because not being present in the dispatch table meant falling
-    # back to save_global, which was already overriden by cloudpickle. Using
-    # the c pickler, save_global cannot be overriden, so we have manually check
-    # is obj's comes from a custom metaclass, and in this case, direct the
-    # object to save_global.
     t = type(obj)
 
     try:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,4 @@ psutil
 futures; python_version < '3.4'
 # Code coverage uploader for Travis:
 codecov
+coverage

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1829,7 +1829,7 @@ class CloudPickleTest(unittest.TestCase):
                 return _TEST_GLOBAL_VARIABLE
             return inner_function
 
-        globals_ = cloudpickle.CloudPickler.extract_code_globals(
+        globals_ = cloudpickle.cloudpickle._extract_code_globals(
             function_factory.__code__)
         assert globals_ == {'_TEST_GLOBAL_VARIABLE'}
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -961,7 +961,7 @@ class CloudPickleTest(unittest.TestCase):
             logger = cloudpickle.loads(base64.b32decode(b'{}'))
             logger.info('hello')
             """.format(base64.b32encode(dumped).decode('ascii'))
-        proc = subprocess.Popen([sys.executable, "-c", code],
+        proc = subprocess.Popen([sys.executable, "-W ignore", "-c", code],
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT)
         out, _ = proc.communicate()

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1840,20 +1840,10 @@ class CloudPickleTest(unittest.TestCase):
 
     def test_recursion_during_pickling(self):
         class A:
-            def __init__(self, some_attribute):
-                self.some_attribute = some_attribute
+            def __getattr__(self, name):
+                return getattr(self, name)
 
-            def __reduce__(self):
-                # Make some_attribute an initarg instead of a state item.  This
-                # makes the reducer unsafe with regards to reference cycles as
-                # cloudpickle will try to some_attribute before self is
-                # memoized.
-                return A, (self.some_attribute, ), {}
-
-        a = A(None)
-
-        # generate a reference cycle
-        a.some_attribute = a
+        a = A()
         with pytest.raises(pickle.PicklingError, match='recursion'):
             cloudpickle.dumps(a)
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1077,7 +1077,9 @@ class CloudPickleTest(unittest.TestCase):
         # serializable.
         from cloudpickle import CloudPickler
         if sys.version_info[:2] >= (3, 8):
-            CloudPickler.dispatch[type(py.builtin)] = cloudpickle.module_reduce
+            from cloudpickle import cloudpickle_fast as cp_fast
+            CloudPickler.dispatch[
+                type(py.builtin)] = cp_fast._module_reduce
         else:
             CloudPickler.dispatch[type(py.builtin)] = CloudPickler.save_module
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1076,7 +1076,11 @@ class CloudPickleTest(unittest.TestCase):
         # some setup is required to allow pytest apimodules to be correctly
         # serializable.
         from cloudpickle import CloudPickler
-        CloudPickler.dispatch[type(py.builtin)] = cloudpickle.module_reduce
+        if sys.version_info[:2] >= (3, 8):
+            CloudPickler.dispatch[type(py.builtin)] = cloudpickle.module_reduce
+        else:
+            CloudPickler.dispatch[type(py.builtin)] = CloudPickler.save_module
+
         g = cloudpickle.loads(cloudpickle.dumps(f, protocol=self.protocol))
 
         result = g()

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1100,9 +1100,6 @@ class CloudPickleTest(unittest.TestCase):
         cloned = pickle_depickle(func, protocol=self.protocol)
         self.assertEqual(cloned.__qualname__, func.__qualname__)
 
-    # @pytest.mark.skipif(sys.version_info >= (3, 8),
-    #                     reason="pickling namedtuple is broken on 3.8")
-
     def test_namedtuple(self):
         MyTuple = collections.namedtuple('MyTuple', ['a', 'b', 'c'])
         t1 = MyTuple(1, 2, 3)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -190,7 +190,7 @@ def assert_run_python_script(source_code, timeout=TIMEOUT):
     try:
         with open(source_file, 'wb') as f:
             f.write(source_code.encode('utf-8'))
-        cmd = [sys.executable, source_file]
+        cmd = [sys.executable, '-W ignore', source_file]
         cwd, env = _make_cwd_env()
         kwargs = {
             'cwd': cwd,

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -72,6 +72,10 @@ def subprocess_pickle_echo(input_data, protocol=None, timeout=TIMEOUT):
 
     """
     # run then pickle_echo(protocol=protocol) in __main__:
+
+    # Protect stderr from any warning, as we will assume an error will happen
+    # if it is not empty. A concrete example is pytest using the imp module,
+    # which is deprecated in python 3.8
     cmd = [sys.executable, '-W ignore', __file__, "--protocol", str(protocol)]
     cwd, env = _make_cwd_env()
     proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, cwd=cwd, env=env,


### PR DESCRIPTION
Summary:
========

This PR proposes a new ``Cloudpickler`` class, that inherits from the C
``_pickle.Pickler`` instead of the python ``pickle._Pickler``, allowing 10x+
speedups for the serialization of large builtin objects such as dicts, lists..

Disclaimer: a new start
=======================
Moving from the python to the c ``Pickler`` requires a fair amount of changes.
For this reason, instead of simply adapting the current code to respect the new
constraints, I started back from scratch. This allows a new, clean API and
structure, that will be hopefully easier to understand for everyone.

I made a lot of comments, (sometimes overly verbose), to ease the review
process of this PR. Eventually, I hope the information they contain can be
transfered to a proper project documentation.

Implementation:
===============

Changes to python
-----------------

As opposed to the python pickler, The CPickler does not expose the ``save_*``
family of functions, as well as low level isntructions such as ``write``. These
methods can can neither be patched, or called, and the only customization
option we had initially was the dispatch table, that is called for all types
BUT a few special cases, including classes and functions, the two principal
use-cases of cloudpickle.

As this makes it simply impossible to modify pickling behavior for such types,
we patched the C pickler for it to allow a user defined reduction callback for
functions and classes. This idea was suggested by @pitrou.

The direct consequence is that functions and classes now have to follow the
``save_reduce``-``load_build`` pickling/depickling process. Unfortunaltely,
this API is not well suited for custom ``builtin``-type saving: in particular,
the state setting part of ``load_build`` (function that reconstructs an object from
a reduce value) assumes all attributes of an object are writeable, which is not
the case for C types (especially ``function.__globals__`` and
``function.__closure__``)

For this reason, we also changed the API of ``save_reduce``, allowing to add a
custom ``state_setter``, that will be called at unpickling time.


You can view the totals changes in [this diff](
https://github.com/python/cpython/compare/master...pierreglaser:add-global-hook?expand=1)

Individual PRs to CPython:
- https://github.com/python/cpython/pull/12499 (`reducer_override`)
- https://github.com/python/cpython/pull/12588 (`state_setter` in `save_reduce`)

Changes to cloudpickle
----------------------

Functions and classes are the two main types affected by this PR. The main
challenge was to make the saving process fit into the ``save_reduce`` API.

Outside of these types, the actuall reduction process remains intact.

However, now that any customization must return a tuple, I decided to adopt a
new naming, hopefully clearer naming style for functions. You will see by
yourselves.


How to build this version locally
=================================

Until the final release of `Python 3.8`, you need to build python from upstream's master branch

```sh
git clone git@github.com:python/cpython.git
cd cpython
./configure
make
```

To be able to use external modules you need a virtual environment, using for
example the ``venv`` module:

```sh
./python -m venv /path/to/local/virtualenv
```

Clone and install ``cloudpickle`` and its dependencies

```sh
cd /path/to/cloudpickle
git clone git@github.com:cloudpipe/cloudpickle.git
git fetch origin pull/ID/head:fast-cloudpickle
/path/to/local/virtualenv/bin/python -mpip install -rdev-requirements.txt
/path/to/local/virtualenv/bin/python -mpip install .
```

Finally, rum the tests:

```sh
/path/to/local/virtualenv/bin/python -mpytest tests/
```


Bechmarks:
==========

- Benchmarks of a "concrete", end-to-end use-case using `loky` can be found
  [here](https://gist.github.com/pierreglaser/26207c20dd8526d6df7963044a3e4477). To run the benchmarks, you also need the master version of loky.
