### PR TITLE
Fix relative imports inside function body

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+0.8.1
+=====
+
+- Fix a bug (already present before 0.5.3 and re-introduced in 0.8.0)
+  affecting relative import instructions inside depickled functions
+  ([issue #254](https://github.com/cloudpipe/cloudpickle/pull/254))
+
 0.8.0
 =====
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -670,7 +670,9 @@ class CloudPickler(Pickler):
             # Add module attributes used to resolve relative imports
             # instructions inside func.
             for k in ["__package__", "__name__", "__path__", "__file__"]:
-                if k in func.__globals__:
+                # Some built-in functions/methods such as object.__new__  have
+                # their __globals__ set to None in PyPy
+                if func.__globals__ is not None and k in func.__globals__:
                     base_globals[k] = func.__globals__[k]
 
         return (code, f_globals, defaults, closure, dct, base_globals)

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -666,6 +666,13 @@ class CloudPickler(Pickler):
         # multiple invokations are bound to the same Cloudpickler.
         base_globals = self.globals_ref.setdefault(id(func.__globals__), {})
 
+        if base_globals == {}:
+            # Add module attributes used to resolve relative imports
+            # instructions inside func.
+            for k in ["__package__", "__name__", "__path__", "__file__"]:
+                if k in func.__globals__:
+                    base_globals[k] = func.__globals__[k]
+
         return (code, f_globals, defaults, closure, dct, base_globals)
 
     def save_builtin_function(self, obj):

--- a/tests/mypkg/__init__.py
+++ b/tests/mypkg/__init__.py
@@ -1,0 +1,6 @@
+from .mod import module_function
+
+
+def package_function():
+    """Function living inside a package, not a simple module"""
+    return "hello from a package!"

--- a/tests/mypkg/mod.py
+++ b/tests/mypkg/mod.py
@@ -1,0 +1,2 @@
+def module_function():
+    return "hello from a module!"


### PR DESCRIPTION
Closes #251 

## `__package__` should be enough to solve relative imports...
Trying to do a relative import inside a function roundtripped by `cloudpickle` is currently broken, because python has no idea of where the function doing the import comes from. Although the traceback of #251  mention `__name__`,  python relies preferably on the `__package__` attribute, before falling back to `__name__` and `__path__` if not available. Refer to the [`_calc__package__`]( https://github.com/python/cpython/blob/3208880f1c72800bacf94a2045fcb0436702c7a1/Lib/importlib/_bootstrap.py#L1054-L1079) function of `importlib`, and [PEP 366](https://www.python.org/dev/peps/pep-0366/) for further details.

Therefore, aside from non-adversarial tests-cases (e.g unmodified dunder attributes), I have not encountered any situation when simply passing `__package__` does not suffice to resolve relative imports.

## ... But what about other classic dunder attributes?
However, I ended up passing `__name__`, `__file__` and `__path__` also, because why not, they are small attributes, and also maybe they are/will be used in some place we do not know yet. Overall, I am +0 to pass them, and I will be happy to hear enlightened reflections about it.


I did not pass `__spec__`, `__loader__` because their semantic is too close to explicitly imported modules, while we are simply creating a global namespace. I did not pass `__doc__`, because it may be big when the pickled function is a nested function of a documented, file-backed module.