### PR TITLE
Add ray tests to ci configuration against the development version of cloudpickle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,8 @@ install:
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle/cloudpickle.py $RAY_DIR/cloudpickle/cloudpickle.py;
-            PROJECT_DIR="$PROJECT_DIR/test";
+            mv $PROJECT_DIR/test $PROJECT_DIR/tests
+            PROJECT_DIR="$PROJECT_DIR";
         else
             pushd ..;
             PROJECT_DIR="../$PROJECT";

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,50 +3,50 @@ dist: xenial
 
 matrix:
   include:
-    - os: windows
-      language: sh
-      env: PYTHON_ROOT="/c/Python37" PYTHON_CHOCO_PKG="python3"
-    - os: windows
-      language: sh
-      env: PYTHON_ROOT="/c/Python27" PYTHON_CHOCO_PKG="python2"
-    - os: linux
-      dist: trusty
-      python: "pypy3"
-    - os: linux
-      python: 3.7
-    - os: linux
-      python: 3.6
-    - os: linux
-      python: 3.5
-    - os: linux
-      python: 2.7
-    - os: linux
-      # The PROJECT environment variable refers to a downstream project that
-      # depends on cloudpickle (for example: distributed, joblib, loky). For
-      # each project, a matrix item is created, that will run the $PROJECT
-      # test suite with the latest cloudpickle, to check for breaking changes
-      # introduced by cloudpickle.
-      # Side note: for distributed, the pytest major version is constrained to
-      # 3 because running it's test suite with pytest 4 fails for now. Also,
-      # two failing tests related to openssl and not to cloudpickle are
-      # skipped
-      python: 3.7
-      sudo: required
-      env: PROJECT=distributed
-           TEST_REQUIREMENTS="pytest==3.6 numpy pandas mock bokeh"
-           PROJECT_URL=https://github.com/dask/distributed.git
-           PYTEST_ARGS="-k not test_connection_args and not test_listen_args"
-      if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
-    - os: linux
-      env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"
-           PROJECT_URL=https://github.com/tomMoral/loky.git
-      python: 3.7
-      if: commit_message =~ /(\[ci downstream\]|\[ci loky\])/
-    - os: linux
-      env: PROJECT=joblib TEST_REQUIREMENTS="pytest numpy distributed"
-           PROJECT_URL=https://github.com/joblib/joblib.git
-      python: 3.7
-      if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
+    # - os: windows
+    #   language: sh
+    #   env: PYTHON_ROOT="/c/Python37" PYTHON_CHOCO_PKG="python3"
+    # - os: windows
+    #   language: sh
+    #   env: PYTHON_ROOT="/c/Python27" PYTHON_CHOCO_PKG="python2"
+    # - os: linux
+    #   dist: trusty
+    #   python: "pypy3"
+    # - os: linux
+    #   python: 3.7
+    # - os: linux
+    #   python: 3.6
+    # - os: linux
+    #   python: 3.5
+    # - os: linux
+    #   python: 2.7
+    # - os: linux
+    #   # The PROJECT environment variable refers to a downstream project that
+    #   # depends on cloudpickle (for example: distributed, joblib, loky). For
+    #   # each project, a matrix item is created, that will run the $PROJECT
+    #   # test suite with the latest cloudpickle, to check for breaking changes
+    #   # introduced by cloudpickle.
+    #   # Side note: for distributed, the pytest major version is constrained to
+    #   # 3 because running it's test suite with pytest 4 fails for now. Also,
+    #   # two failing tests related to openssl and not to cloudpickle are
+    #   # skipped
+    #   python: 3.7
+    #   sudo: required
+    #   env: PROJECT=distributed
+    #        TEST_REQUIREMENTS="pytest==3.6 numpy pandas mock bokeh"
+    #        PROJECT_URL=https://github.com/dask/distributed.git
+    #        PYTEST_ARGS="-k not test_connection_args and not test_listen_args"
+    #   if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
+    # - os: linux
+    #   env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"
+    #        PROJECT_URL=https://github.com/tomMoral/loky.git
+    #   python: 3.7
+    #   if: commit_message =~ /(\[ci downstream\]|\[ci loky\])/
+    # - os: linux
+    #   env: PROJECT=joblib TEST_REQUIREMENTS="pytest numpy distributed"
+    #        PROJECT_URL=https://github.com/joblib/joblib.git
+    #   python: 3.7
+    #   if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
     - os: linux
       env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis"
            PROJECT_URL=https://github.com/ray-project/ray.git
@@ -110,7 +110,7 @@ script:
       if [[ "$TEST_RETURN_CODE" != "0" ]]; then
         exit $TEST_RETURN_CODE
       fi
-      popd
+      # popd
     fi
 after_success:
   - coverage combine --append

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,13 +77,11 @@ install:
             pushd ..;
             PROJECT_DIR="../$PROJECT";
             git clone $PROJECT_URL;
-        fi;
-        if [[ $PROJECT == "joblib" ]]; then
-            pushd joblib/joblib/externals;
-            source vendor_cloudpickle.sh ../../../cloudpickle;
-            popd;
-        fi;
-        if [[ $PROJECT != "ray" ]]; then
+            if [[ $PROJECT == "joblib" ]]; then
+                pushd joblib/joblib/externals;
+                source vendor_cloudpickle.sh ../../../cloudpickle;
+                popd;
+            fi;
             pip install ./$PROJECT;
             popd;
         fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,11 +70,13 @@ install:
         pip install $TEST_REQUIREMENTS;
         pushd ..;
         if [[ $PROJECT == "ray" ]]; then
-            RAY_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
+            PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $RAY_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle/cloudpickle.py $RAY_DIR/cloudpickle/cloudpickle.py;
+        else
+            PROJECT_DIR="../$PROJECT";
+            git clone $PROJECT_URL;
         fi;
-        git clone $PROJECT_URL;
         if [[ $PROJECT == "joblib" ]]; then
             pushd joblib/joblib/externals;
             source vendor_cloudpickle.sh ../../../cloudpickle;
@@ -96,7 +98,7 @@ script:
   - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
   - |
     if [[ $PROJECT != "" ]]; then
-      pushd ../$PROJECT
+      pushd $PROJECT_DIR
       # pytest hangs if given an empty quoted string (it will happen
       # if PYTEST_ARGS was not defined) so we have to split the cases.
       if [[ "$PYTEST_ARGS" != "" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
       python: 3.7
       if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
     - os: linux
-      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil flaky networkx tensorflow scipy"
+      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil flaky networkx tensorflow scipy Cython==0.29"
            PROJECT_URL=https://github.com/ray-project/ray.git
            PYTEST_ARGS="--duration=10"
       python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ install:
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle/cloudpickle.py $RAY_DIR/cloudpickle/cloudpickle.py;
             mv $PROJECT_DIR/test $PROJECT_DIR/tests;
-            PROJECT_DIR="$PROJECT_DIR";
+            PROJECT_DIR="$PROJECT_DIR/test";
         else
             pushd ..;
             PROJECT_DIR="../$PROJECT";

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,10 +66,10 @@ matrix:
         - pushd $PROJECT_DIR
         - pytest -vl --duration=10 $PROJECT_DIR/test_mini.py
         - TEST_RETURN_CODE=$?
-        - if [[ "$TEST_RETURN_CODE" != "0" ]]; then
-            exit $TEST_RETURN_CODE;
-          fi;
         - popd
+        - if [[ "$TEST_RETURN_CODE" != "0" ]]; then
+            exit $TEST_RETURN_CODE
+          fi
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,9 @@ matrix:
       install:
         - pip install --upgrade -r dev-requirements.txt
         - pip install setproctitle psutil ray==0.6.4
-        - PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")"
+        - PROJECT_DIR="PROJECT_DIR="$(python -c "import os,ray; print(os.path.dirname(ray.__file__), flush=True)"
         - rm $PROJECT_DIR/cloudpickle/cloudpickle.py
         - cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py
-        - pip list
       script:
         - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
         - pytest -vl --duration=10 $PROJECT_DIR/tests/test_mini.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,28 +48,20 @@ matrix:
       python: 3.7
       if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
     - os: linux
-      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle psutil"
+      env: PROJECT=ray
       python: 3.7
       if: commit_message =~ /(\[ci downstream\]|\[ci ray\])/
       install:
-        - pip install .
         - pip install --upgrade -r dev-requirements.txt
-        - pip install $TEST_REQUIREMENTS;
-        - pip install ray==0.6.4;
-        - PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
-        - rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
-        - cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py;
-        - PROJECT_DIR="$PROJECT_DIR/tests";
+        - pip install setproctitle psutil ray==0.6.4
+        - PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")"
+        - rm $PROJECT_DIR/cloudpickle/cloudpickle.py
+        - cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py
+        - PROJECT_DIR="$PROJECT_DIR/tests"
         - pip list
       script:
         - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
-        - pushd $PROJECT_DIR
         - pytest -vl --duration=10 $PROJECT_DIR/test_mini.py
-        - TEST_RETURN_CODE=$?
-        - popd
-        - if [[ "$TEST_RETURN_CODE" != "0" ]]; then
-            exit $TEST_RETURN_CODE
-          fi
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,8 @@ matrix:
         - pytest -vl --duration=10 $PROJECT_DIR/test_mini.py
         - TEST_RETURN_CODE=$?
         - if [[ "$TEST_RETURN_CODE" != "0" ]]; then
-            exit $TEST_RETURN_CODE
-          fi
+            exit $TEST_RETURN_CODE;
+          fi;
         - popd
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ install:
             pushd ..;
             git clone $PROJECT_URL;
             pushd ray/examples/cython;
-            pip install -e .;
+            pip install -e . ;
             popd;
             rm -rf ray;
             popd;

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,9 @@ install:
         pip install $TEST_REQUIREMENTS;
         if [[ $PROJECT == "ray" ]]; then
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
-            rm $RAY_DIR/cloudpickle/cloudpickle.py;
+            rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle/cloudpickle.py $RAY_DIR/cloudpickle/cloudpickle.py;
+            PROJECT_DIR="$PROJECT_DIR/test"
         else
             pushd ..;
             PROJECT_DIR="../$PROJECT";

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,7 @@ install:
   - if [[ $PROJECT != "" ]]; then
         pip install $TEST_REQUIREMENTS;
         if [[ $PROJECT == "ray" ]]; then
-            wget https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev0-cp37-cp37m-manylinux1_x86_64.whl;
-            pip install ray-0.7.0.dev0-cp37-cp37m-manylinux1_x86_64.whl;
+            pip install ray;
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py;

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ matrix:
       python: 3.7
       if: commit_message =~ /(\[ci downstream\]|\[ci ray\])/
       install:
-        - pip install --upgrade -r dev-requirements.txt
         - pip install setproctitle psutil ray==0.6.4
         - PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")"
         - rm $PROJECT_DIR/cloudpickle/cloudpickle.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
     - os: linux
       env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil flaky networkx tensorflow"
            PROJECT_URL=https://github.com/ray-project/ray.git
-           PYTEST_ARGS="--ignore=test_cython.py"
+           PYTEST_ARGS="--ignore=test_cython.py --duration=10"
       python: 3.7
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,15 @@ matrix:
         - cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py;
         - PROJECT_DIR="$PROJECT_DIR/tests";
         - pip list
+      script:
+        - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
+        - pushd $PROJECT_DIR
+        - pytest -vl --duration=10 $PROJECT_DIR/test_mini.py $PROJECT_DIR/test_basic.py
+        - TEST_RETURN_CODE=$?
+        - if [[ "$TEST_RETURN_CODE" != "0" ]]; then
+            exit $TEST_RETURN_CODE
+          fi
+        - popd
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
@@ -105,7 +114,7 @@ script:
   - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
   - |
     if [[ $PROJECT != "" ]]; then
-      pushd $PROJECT_DIR
+      pushd "../$PROJECT"
       # pytest hangs if given an empty quoted string (it will happen
       # if PYTEST_ARGS was not defined) so we have to split the cases.
       if [[ "$PYTEST_ARGS" != "" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
     - os: linux
       env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil flaky networkx tensorflow"
            PROJECT_URL=https://github.com/ray-project/ray.git
-           PYTEST_ARGS="--ignore=test_cython.py --duration=10"
+           PYTEST_ARGS="--ignore=test_cython.py  --duration=10"
       python: 3.7
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,8 @@ matrix:
       env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil"
            PROJECT_URL=https://github.com/ray-project/ray.git
            PYTEST_ARGS="--duration=10"
-      python: 3.5
+      if: commit_message =~ /(\[ci downstream\]|\[ci ray\])/
+      python: 3.7
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
@@ -69,7 +70,8 @@ install:
   - if [[ $PROJECT != "" ]]; then
         pip install $TEST_REQUIREMENTS;
         if [[ $PROJECT == "ray" ]]; then
-            pip install ray;
+            wget https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev0-cp37-cp37m-manylinux1_x86_64.whl -O ray.whl
+            pip install ray.whl
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py;

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ matrix:
            PROJECT_URL=https://github.com/ray-project/ray.git
            PYTEST_ARGS="--duration=10"
       python: 3.7
+      if: commit_message =~ /(\[ci downstream\]|\[ci ray\])/
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,6 @@ install:
   - if [[ $PROJECT != "" ]]; then
         pip install $TEST_REQUIREMENTS;
         pushd ..;
-        PROJECT_DIR="../$PROJECT";
         git clone $PROJECT_URL;
         if [[ $PROJECT == "joblib" ]]; then
             pushd joblib/joblib/externals;
@@ -114,7 +113,7 @@ script:
   - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
   - |
     if [[ $PROJECT != "" ]]; then
-      pushd "../$PROJECT"
+      pushd ../$PROJECT
       # pytest hangs if given an empty quoted string (it will happen
       # if PYTEST_ARGS was not defined) so we have to split the cases.
       if [[ "$PYTEST_ARGS" != "" ]]; then
@@ -123,10 +122,10 @@ script:
         pytest -vl
       fi
       TEST_RETURN_CODE=$?
+      popd
       if [[ "$TEST_RETURN_CODE" != "0" ]]; then
         exit $TEST_RETURN_CODE
       fi
-      popd
     fi
 after_success:
   - coverage combine --append

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,7 @@ matrix:
       python: 3.7
       if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
     - os: linux
-      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil"
-           PROJECT_URL=https://github.com/ray-project/ray.git
-           PYTEST_ARGS="--duration=10 -k test_mini or test_basic"
+      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle psutil"
       python: 3.7
       if: commit_message =~ /(\[ci downstream\]|\[ci ray\])/
       install:
@@ -70,7 +68,7 @@ matrix:
       script:
         - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
         - pushd $PROJECT_DIR
-        - pytest -vl --duration=10 $PROJECT_DIR/test_mini.py $PROJECT_DIR/test_basic.py
+        - pytest -vl --duration=10 $PROJECT_DIR/test_mini.py
         - TEST_RETURN_CODE=$?
         - if [[ "$TEST_RETURN_CODE" != "0" ]]; then
             exit $TEST_RETURN_CODE

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
       install:
         - pip install --upgrade -r dev-requirements.txt
         - pip install setproctitle psutil ray==0.6.4
-        - PROJECT_DIR="$(python -c "import os,ray; print(os.path.dirname(ray.__file__), flush=True)"
+        - PROJECT_DIR="$(python -c "import os,ray; print(os.path.dirname(ray.__file__), flush=True)")"
         - rm $PROJECT_DIR/cloudpickle/cloudpickle.py
         - cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ matrix:
         - PROJECT_DIR="$PROJECT_DIR/tests"
         - pip list
       script:
-        # - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
+        - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
         - pytest -vl --duration=10 $PROJECT_DIR/test_mini.py
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
     - os: linux
       env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil flaky networkx tensorflow"
            PROJECT_URL=https://github.com/ray-project/ray.git
-           PYTEST_ARGS="--duration=10 --ignore=test_cython.py"
+           PYTEST_ARGS="--ignore=test_cython.py"
       python: 3.7
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ matrix:
         - PROJECT_DIR="$PROJECT_DIR/tests"
         - pip list
       script:
-        - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
+        # - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
         - pytest -vl --duration=10 $PROJECT_DIR/test_mini.py
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
     #   python: 3.7
     #   if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
     - os: linux
-      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis"
+      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil"
            PROJECT_URL=https://github.com/ray-project/ray.git
            PYTEST_ARGS="--duration=10"
       python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ install:
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle/cloudpickle.py $RAY_DIR/cloudpickle/cloudpickle.py;
-            mv $PROJECT_DIR/test $PROJECT_DIR/tests
+            mv $PROJECT_DIR/test $PROJECT_DIR/tests;
             PROJECT_DIR="$PROJECT_DIR";
         else
             pushd ..;

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ install:
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle/cloudpickle.py $RAY_DIR/cloudpickle/cloudpickle.py;
-            PROJECT_DIR="$PROJECT_DIR/test"
+            PROJECT_DIR="$PROJECT_DIR/test";
         else
             pushd ..;
             PROJECT_DIR="../$PROJECT";

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
     - os: linux
       env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil flaky networkx tensorflow"
            PROJECT_URL=https://github.com/ray-project/ray.git
-           PYTEST_ARGS="--ignore=test_cython.py  --duration=10"
+           PYTEST_ARGS="--duration=10"
       python: 3.7
 
 before_install:
@@ -74,6 +74,7 @@ install:
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py;
             PROJECT_DIR="$PROJECT_DIR/tests";
+            rm $PROJECT_DIR/test_cython.py;
         else
             pushd ..;
             PROJECT_DIR="../$PROJECT";

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,11 +97,12 @@ before_script:
 script:
   - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
   - |
+    pushd $PROJECT_DIR
     if [[ $PROJECT != "" ]]; then
       # pytest hangs if given an empty quoted string (it will happen
       # if PYTEST_ARGS was not defined) so we have to split the cases.
       if [[ "$PYTEST_ARGS" != "" ]]; then
-        pytest -vl $PROJECT_DIR "$PYTEST_ARGS"
+        pytest -vl "$PYTEST_ARGS"
       else
         pytest -vl
       fi
@@ -109,6 +110,7 @@ script:
       if [[ "$TEST_RETURN_CODE" != "0" ]]; then
         exit $TEST_RETURN_CODE
       fi
+      popd
     fi
 after_success:
   - coverage combine --append

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,50 +3,50 @@ dist: xenial
 
 matrix:
   include:
-    # - os: windows
-    #   language: sh
-    #   env: PYTHON_ROOT="/c/Python37" PYTHON_CHOCO_PKG="python3"
-    # - os: windows
-    #   language: sh
-    #   env: PYTHON_ROOT="/c/Python27" PYTHON_CHOCO_PKG="python2"
-    # - os: linux
-    #   dist: trusty
-    #   python: "pypy3"
-    # - os: linux
-    #   python: 3.7
-    # - os: linux
-    #   python: 3.6
-    # - os: linux
-    #   python: 3.5
-    # - os: linux
-    #   python: 2.7
-    # - os: linux
-    #   # The PROJECT environment variable refers to a downstream project that
-    #   # depends on cloudpickle (for example: distributed, joblib, loky). For
-    #   # each project, a matrix item is created, that will run the $PROJECT
-    #   # test suite with the latest cloudpickle, to check for breaking changes
-    #   # introduced by cloudpickle.
-    #   # Side note: for distributed, the pytest major version is constrained to
-    #   # 3 because running it's test suite with pytest 4 fails for now. Also,
-    #   # two failing tests related to openssl and not to cloudpickle are
-    #   # skipped
-    #   python: 3.7
-    #   sudo: required
-    #   env: PROJECT=distributed
-    #        TEST_REQUIREMENTS="pytest==3.6 numpy pandas mock bokeh"
-    #        PROJECT_URL=https://github.com/dask/distributed.git
-    #        PYTEST_ARGS="-k not test_connection_args and not test_listen_args"
-    #   if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
-    # - os: linux
-    #   env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"
-    #        PROJECT_URL=https://github.com/tomMoral/loky.git
-    #   python: 3.7
-    #   if: commit_message =~ /(\[ci downstream\]|\[ci loky\])/
-    # - os: linux
-    #   env: PROJECT=joblib TEST_REQUIREMENTS="pytest numpy distributed"
-    #        PROJECT_URL=https://github.com/joblib/joblib.git
-    #   python: 3.7
-    #   if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
+    - os: windows
+      language: sh
+      env: PYTHON_ROOT="/c/Python37" PYTHON_CHOCO_PKG="python3"
+    - os: windows
+      language: sh
+      env: PYTHON_ROOT="/c/Python27" PYTHON_CHOCO_PKG="python2"
+    - os: linux
+      dist: trusty
+      python: "pypy3"
+    - os: linux
+      python: 3.7
+    - os: linux
+      python: 3.6
+    - os: linux
+      python: 3.5
+    - os: linux
+      python: 2.7
+    - os: linux
+      # The PROJECT environment variable refers to a downstream project that
+      # depends on cloudpickle (for example: distributed, joblib, loky). For
+      # each project, a matrix item is created, that will run the $PROJECT
+      # test suite with the latest cloudpickle, to check for breaking changes
+      # introduced by cloudpickle.
+      # Side note: for distributed, the pytest major version is constrained to
+      # 3 because running it's test suite with pytest 4 fails for now. Also,
+      # two failing tests related to openssl and not to cloudpickle are
+      # skipped
+      python: 3.7
+      sudo: required
+      env: PROJECT=distributed
+           TEST_REQUIREMENTS="pytest==3.6 numpy pandas mock bokeh"
+           PROJECT_URL=https://github.com/dask/distributed.git
+           PYTEST_ARGS="-k not test_connection_args and not test_listen_args"
+      if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
+    - os: linux
+      env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"
+           PROJECT_URL=https://github.com/tomMoral/loky.git
+      python: 3.7
+      if: commit_message =~ /(\[ci downstream\]|\[ci loky\])/
+    - os: linux
+      env: PROJECT=joblib TEST_REQUIREMENTS="pytest numpy distributed"
+           PROJECT_URL=https://github.com/joblib/joblib.git
+      python: 3.7
+      if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
     - os: linux
       env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil"
            PROJECT_URL=https://github.com/ray-project/ray.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,25 @@ matrix:
       python: 3.7
       if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
     - os: linux
-      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil flaky networkx tensorflow scipy Cython==0.29"
+      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil"
            PROJECT_URL=https://github.com/ray-project/ray.git
-           PYTEST_ARGS="--duration=10"
+           PYTEST_ARGS="--duration=10 -k test_mini or test_basic"
       python: 3.7
       if: commit_message =~ /(\[ci downstream\]|\[ci ray\])/
+      install:
+        - pip install .
+        - pip install --upgrade -r dev-requirements.txt
+        - pip install tornado
+        - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
+              pip install numpy scipy;
+          fi
+        - pip install $TEST_REQUIREMENTS;
+        - pip install ray==0.6.4;
+        - PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
+        - rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
+        - cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py;
+        - PROJECT_DIR="$PROJECT_DIR/tests";
+        - pip list
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
@@ -69,31 +83,16 @@ install:
     fi
   - if [[ $PROJECT != "" ]]; then
         pip install $TEST_REQUIREMENTS;
-        if [[ $PROJECT == "ray" ]]; then
-            pushd ..;
-            git clone $PROJECT_URL;
-            pushd ray/examples/cython;
-            python setup.py install;
-            popd;
-            rm -rf ray/;
-            popd;
-            pip install ray;
-            PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
-            rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
-            cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py;
-            PROJECT_DIR="$PROJECT_DIR/tests";
-        else
-            pushd ..;
-            PROJECT_DIR="../$PROJECT";
-            git clone $PROJECT_URL;
-            if [[ $PROJECT == "joblib" ]]; then
-                pushd joblib/joblib/externals;
-                source vendor_cloudpickle.sh ../../../cloudpickle;
-                popd;
-            fi;
-            pip install ./$PROJECT;
+        pushd ..;
+        PROJECT_DIR="../$PROJECT";
+        git clone $PROJECT_URL;
+        if [[ $PROJECT == "joblib" ]]; then
+            pushd joblib/joblib/externals;
+            source vendor_cloudpickle.sh ../../../cloudpickle;
             popd;
         fi;
+        pip install ./$PROJECT;
+        popd;
     fi
   - pip list
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ matrix:
       python: 3.7
       if: commit_message =~ /(\[ci downstream\]|\[ci ray\])/
       install:
+        - pip install --upgrade -r dev-requirements.txt
         - pip install setproctitle psutil ray==0.6.4
         - PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")"
         - rm $PROJECT_DIR/cloudpickle/cloudpickle.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
       if: commit_message =~ /(\[ci downstream\]|\[ci ray\])/
       install:
         - pip install --upgrade -r dev-requirements.txt
-        - pip install setproctitle psutil ray==0.6.4
+        - pip install setproctitle psutil py-spy ray==0.6.4
         - PROJECT_DIR="$(python -c "import os, ray; print(os.path.dirname(ray.__file__), flush=True)")"
         - rm $PROJECT_DIR/cloudpickle/cloudpickle.py
         - cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
     #   python: 3.7
     #   if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
     - os: linux
-      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis ray"
+      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis"
            PROJECT_URL=https://github.com/ray-project/ray.git
            PYTEST_ARGS="--duration=10"
       python: 3.5
@@ -69,9 +69,10 @@ install:
   - if [[ $PROJECT != "" ]]; then
         pip install $TEST_REQUIREMENTS;
         if [[ $PROJECT == "ray" ]]; then
+            pip install ray
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
-            cp cloudpickle/cloudpickle/cloudpickle.py $RAY_DIR/cloudpickle/cloudpickle.py;
+            cp cloudpickle/cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py;
             PROJECT_DIR="$PROJECT_DIR/test";
         else
             pushd ..;

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,15 +70,13 @@ install:
   - if [[ $PROJECT != "" ]]; then
         pip install $TEST_REQUIREMENTS;
         if [[ $PROJECT == "ray" ]]; then
-            # Install cython_examples
             pushd ..;
             git clone $PROJECT_URL;
             pushd ray/examples/cython;
             python setup.py install;
             popd;
-            rm -rf ray;
+            rm -rf ray/;
             popd;
-            # Install ray
             pip install ray;
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ matrix:
       script:
         - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
         - pytest -vl --duration=10 $PROJECT_DIR/tests/test_basic.py
+        - pytest -vl --duration=10 $PROJECT_DIR/tests/test_recursion.py
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,6 @@ matrix:
       install:
         - pip install .
         - pip install --upgrade -r dev-requirements.txt
-        - pip install tornado
-        - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
-              pip install numpy scipy;
-          fi
         - pip install $TEST_REQUIREMENTS;
         - pip install ray==0.6.4;
         - PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ dist: xenial
 
 matrix:
   include:
-    # - os: windows
-    #   language: sh
-    #   env: PYTHON_ROOT="/c/Python37" PYTHON_CHOCO_PKG="python3"
+    - os: windows
+      language: sh
+      env: PYTHON_ROOT="/c/Python37" PYTHON_CHOCO_PKG="python3"
     # - os: windows
     #   language: sh
     #   env: PYTHON_ROOT="/c/Python27" PYTHON_CHOCO_PKG="python2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
       install:
         - pip install --upgrade -r dev-requirements.txt
         - pip install setproctitle psutil ray==0.6.4
-        - PROJECT_DIR="PROJECT_DIR="$(python -c "import os,ray; print(os.path.dirname(ray.__file__), flush=True)"
+        - PROJECT_DIR="$(python -c "import os,ray; print(os.path.dirname(ray.__file__), flush=True)"
         - rm $PROJECT_DIR/cloudpickle/cloudpickle.py
         - cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ install:
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py;
-            PROJECT_DIR="$PROJECT_DIR/test";
+            PROJECT_DIR="$PROJECT_DIR/tests";
         else
             pushd ..;
             PROJECT_DIR="../$PROJECT";

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ matrix:
       env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil"
            PROJECT_URL=https://github.com/ray-project/ray.git
            PYTEST_ARGS="--duration=10"
-      if: commit_message =~ /(\[ci downstream\]|\[ci ray\])/
       python: 3.7
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,12 +68,12 @@ install:
     fi
   - if [[ $PROJECT != "" ]]; then
         pip install $TEST_REQUIREMENTS;
-        pushd ..;
         if [[ $PROJECT == "ray" ]]; then
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $RAY_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle/cloudpickle.py $RAY_DIR/cloudpickle/cloudpickle.py;
         else
+            pushd ..;
             PROJECT_DIR="../$PROJECT";
             git clone $PROJECT_URL;
         fi;
@@ -84,8 +84,8 @@ install:
         fi;
         if [[ $PROJECT != "ray" ]]; then
             pip install ./$PROJECT;
+            popd;
         fi;
-        popd;
     fi
   - pip list
 before_script:
@@ -98,16 +98,14 @@ script:
   - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
   - |
     if [[ $PROJECT != "" ]]; then
-      pushd $PROJECT_DIR
       # pytest hangs if given an empty quoted string (it will happen
       # if PYTEST_ARGS was not defined) so we have to split the cases.
       if [[ "$PYTEST_ARGS" != "" ]]; then
-        pytest -vl "$PYTEST_ARGS"
+        pytest -vl --root=$PROJeCT_DIR "$PYTEST_ARGS"
       else
         pytest -vl
       fi
       TEST_RETURN_CODE=$?
-      popd
       if [[ "$TEST_RETURN_CODE" != "0" ]]; then
         exit $TEST_RETURN_CODE
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ script:
       if [[ "$TEST_RETURN_CODE" != "0" ]]; then
         exit $TEST_RETURN_CODE
       fi
-      # popd
+      popd
     fi
 after_success:
   - coverage combine --append

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ install:
             pushd ..;
             git clone $PROJECT_URL;
             pushd ray/examples/cython;
-            pip install -e ./;
+            python setup.py install;
             popd;
             rm -rf ray;
             popd;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,47 +6,47 @@ matrix:
     - os: windows
       language: sh
       env: PYTHON_ROOT="/c/Python37" PYTHON_CHOCO_PKG="python3"
-    # - os: windows
-    #   language: sh
-    #   env: PYTHON_ROOT="/c/Python27" PYTHON_CHOCO_PKG="python2"
-    # - os: linux
-    #   dist: trusty
-    #   python: "pypy3"
-    # - os: linux
-    #   python: 3.7
-    # - os: linux
-    #   python: 3.6
-    # - os: linux
-    #   python: 3.5
-    # - os: linux
-    #   python: 2.7
-    # - os: linux
-    #   # The PROJECT environment variable refers to a downstream project that
-    #   # depends on cloudpickle (for example: distributed, joblib, loky). For
-    #   # each project, a matrix item is created, that will run the $PROJECT
-    #   # test suite with the latest cloudpickle, to check for breaking changes
-    #   # introduced by cloudpickle.
-    #   # Side note: for distributed, the pytest major version is constrained to
-    #   # 3 because running it's test suite with pytest 4 fails for now. Also,
-    #   # two failing tests related to openssl and not to cloudpickle are
-    #   # skipped
-    #   python: 3.7
-    #   sudo: required
-    #   env: PROJECT=distributed
-    #        TEST_REQUIREMENTS="pytest==3.6 numpy pandas mock bokeh"
-    #        PROJECT_URL=https://github.com/dask/distributed.git
-    #        PYTEST_ARGS="-k not test_connection_args and not test_listen_args"
-    #   if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
-    # - os: linux
-    #   env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"
-    #        PROJECT_URL=https://github.com/tomMoral/loky.git
-    #   python: 3.7
-    #   if: commit_message =~ /(\[ci downstream\]|\[ci loky\])/
-    # - os: linux
-    #   env: PROJECT=joblib TEST_REQUIREMENTS="pytest numpy distributed"
-    #        PROJECT_URL=https://github.com/joblib/joblib.git
-    #   python: 3.7
-    #   if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
+    - os: windows
+      language: sh
+      env: PYTHON_ROOT="/c/Python27" PYTHON_CHOCO_PKG="python2"
+    - os: linux
+      dist: trusty
+      python: "pypy3"
+    - os: linux
+      python: 3.7
+    - os: linux
+      python: 3.6
+    - os: linux
+      python: 3.5
+    - os: linux
+      python: 2.7
+    - os: linux
+      # The PROJECT environment variable refers to a downstream project that
+      # depends on cloudpickle (for example: distributed, joblib, loky). For
+      # each project, a matrix item is created, that will run the $PROJECT
+      # test suite with the latest cloudpickle, to check for breaking changes
+      # introduced by cloudpickle.
+      # Side note: for distributed, the pytest major version is constrained to
+      # 3 because running it's test suite with pytest 4 fails for now. Also,
+      # two failing tests related to openssl and not to cloudpickle are
+      # skipped
+      python: 3.7
+      sudo: required
+      env: PROJECT=distributed
+           TEST_REQUIREMENTS="pytest==3.6 numpy pandas mock bokeh"
+           PROJECT_URL=https://github.com/dask/distributed.git
+           PYTEST_ARGS="-k not test_connection_args and not test_listen_args"
+      if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
+    - os: linux
+      env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"
+           PROJECT_URL=https://github.com/tomMoral/loky.git
+      python: 3.7
+      if: commit_message =~ /(\[ci downstream\]|\[ci loky\])/
+    - os: linux
+      env: PROJECT=joblib TEST_REQUIREMENTS="pytest numpy distributed"
+           PROJECT_URL=https://github.com/joblib/joblib.git
+      python: 3.7
+      if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
     - os: linux
       env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil flaky networkx tensorflow"
            PROJECT_URL=https://github.com/ray-project/ray.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
       install:
         - pip install --upgrade -r dev-requirements.txt
         - pip install setproctitle psutil ray==0.6.4
-        - PROJECT_DIR="$(python -c "import os,ray; print(os.path.dirname(ray.__file__), flush=True)")"
+        - PROJECT_DIR="$(python -c "import os, ray; print(os.path.dirname(ray.__file__), flush=True)")"
         - rm $PROJECT_DIR/cloudpickle/cloudpickle.py
         - cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,8 @@ install:
   - if [[ $PROJECT != "" ]]; then
         pip install $TEST_REQUIREMENTS;
         if [[ $PROJECT == "ray" ]]; then
-            wget https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev0-cp37-cp37m-manylinux1_x86_64.whl -O ray.whl
-            pip install ray.whl
+            wget https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev0-cp37-cp37m-manylinux1_x86_64.whl -O ray.whl;
+            pip install ray.whl;
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py;

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
     #   python: 3.7
     #   if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
     - os: linux
-      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle ray"
+      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis ray"
            PROJECT_URL=https://github.com/ray-project/ray.git
            PYTEST_ARGS="--duration=10"
       python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,14 +53,17 @@ matrix:
       if: commit_message =~ /(\[ci downstream\]|\[ci ray\])/
       install:
         - pip install --upgrade -r dev-requirements.txt
-        - pip install setproctitle psutil py-spy ray==0.6.4
+        - pip install setproctitle psutil ray==0.6.4
         - PROJECT_DIR="$(python -c "import os, ray; print(os.path.dirname(ray.__file__), flush=True)")"
         - rm $PROJECT_DIR/cloudpickle/cloudpickle.py
         - cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py
       script:
         - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
-        - pytest -vl --duration=10 $PROJECT_DIR/tests/test_basic.py
-        - pytest -vl --duration=10 $PROJECT_DIR/tests/test_recursion.py
+        - pytest -vl $PROJECT_DIR/tests/test_basic.py::test_simple_serialization
+        - pytest -vl $PROJECT_DIR/tests/test_basic.py::test_complex_serialization
+        - pytest -vl $PROJECT_DIR/tests/test_basic.py::test_ray_recursive_objects
+        - pytest -vl $PROJECT_DIR/tests/test_basic.py::test_serialization_final_fallback
+        - pytest -vl $PROJECT_DIR/tests/test_recursion.py
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ install:
   - if [[ $PROJECT != "" ]]; then
         pip install $TEST_REQUIREMENTS;
         if [[ $PROJECT == "ray" ]]; then
-            pip install ray
+            pip install ray;
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py;

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,6 @@ install:
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle/cloudpickle.py $RAY_DIR/cloudpickle/cloudpickle.py;
-            mv $PROJECT_DIR/test $PROJECT_DIR/tests;
             PROJECT_DIR="$PROJECT_DIR/test";
         else
             pushd ..;

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ script:
       # pytest hangs if given an empty quoted string (it will happen
       # if PYTEST_ARGS was not defined) so we have to split the cases.
       if [[ "$PYTEST_ARGS" != "" ]]; then
-        pytest -vl --root=$PROJeCT_DIR "$PYTEST_ARGS"
+        pytest -vl --root=$PROJECT_DIR "$PYTEST_ARGS"
       else
         pytest -vl
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
       python: 3.7
       if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
     - os: linux
-      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil flaky networkx tensorflow"
+      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil flaky networkx tensorflow scipy"
            PROJECT_URL=https://github.com/ray-project/ray.git
            PYTEST_ARGS="--duration=10"
       python: 3.7
@@ -70,12 +70,21 @@ install:
   - if [[ $PROJECT != "" ]]; then
         pip install $TEST_REQUIREMENTS;
         if [[ $PROJECT == "ray" ]]; then
+            # Install cython_examples
+            pushd ..;
+            git clone $PROJECT_URL;
+            pushd ray/examples/cython;
+            pip install -e .;
+            popd;
+            rm -rf ray;
+            popd;
+
+            # Install ray
             pip install ray;
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py;
             PROJECT_DIR="$PROJECT_DIR/tests";
-            rm $PROJECT_DIR/test_cython.py;
         else
             pushd ..;
             PROJECT_DIR="../$PROJECT";

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ script:
       # pytest hangs if given an empty quoted string (it will happen
       # if PYTEST_ARGS was not defined) so we have to split the cases.
       if [[ "$PYTEST_ARGS" != "" ]]; then
-        pytest -vl --root=$PROJECT_DIR "$PYTEST_ARGS"
+        pytest -vl $PROJECT_DIR "$PYTEST_ARGS"
       else
         pytest -vl
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,11 +74,10 @@ install:
             pushd ..;
             git clone $PROJECT_URL;
             pushd ray/examples/cython;
-            pip install -e . ;
+            pip install -e ./;
             popd;
             rm -rf ray;
             popd;
-
             # Install ray
             pip install ray;
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,50 +3,50 @@ dist: xenial
 
 matrix:
   include:
-    # - os: windows
-    #   language: sh
-    #   env: PYTHON_ROOT="/c/Python37" PYTHON_CHOCO_PKG="python3"
-    # - os: windows
-    #   language: sh
-    #   env: PYTHON_ROOT="/c/Python27" PYTHON_CHOCO_PKG="python2"
-    # - os: linux
-    #   dist: trusty
-    #   python: "pypy3"
-    # - os: linux
-    #   python: 3.7
-    # - os: linux
-    #   python: 3.6
-    # - os: linux
-    #   python: 3.5
-    # - os: linux
-    #   python: 2.7
-    # - os: linux
-    #   # The PROJECT environment variable refers to a downstream project that
-    #   # depends on cloudpickle (for example: distributed, joblib, loky). For
-    #   # each project, a matrix item is created, that will run the $PROJECT
-    #   # test suite with the latest cloudpickle, to check for breaking changes
-    #   # introduced by cloudpickle.
-    #   # Side note: for distributed, the pytest major version is constrained to
-    #   # 3 because running it's test suite with pytest 4 fails for now. Also,
-    #   # two failing tests related to openssl and not to cloudpickle are
-    #   # skipped
-    #   python: 3.7
-    #   sudo: required
-    #   env: PROJECT=distributed
-    #        TEST_REQUIREMENTS="pytest==3.6 numpy pandas mock bokeh"
-    #        PROJECT_URL=https://github.com/dask/distributed.git
-    #        PYTEST_ARGS="-k not test_connection_args and not test_listen_args"
-    #   if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
-    # - os: linux
-    #   env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"
-    #        PROJECT_URL=https://github.com/tomMoral/loky.git
-    #   python: 3.7
-    #   if: commit_message =~ /(\[ci downstream\]|\[ci loky\])/
-    # - os: linux
-    #   env: PROJECT=joblib TEST_REQUIREMENTS="pytest numpy distributed"
-    #        PROJECT_URL=https://github.com/joblib/joblib.git
-    #   python: 3.7
-    #   if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
+    - os: windows
+      language: sh
+      env: PYTHON_ROOT="/c/Python37" PYTHON_CHOCO_PKG="python3"
+    - os: windows
+      language: sh
+      env: PYTHON_ROOT="/c/Python27" PYTHON_CHOCO_PKG="python2"
+    - os: linux
+      dist: trusty
+      python: "pypy3"
+    - os: linux
+      python: 3.7
+    - os: linux
+      python: 3.6
+    - os: linux
+      python: 3.5
+    - os: linux
+      python: 2.7
+    - os: linux
+      # The PROJECT environment variable refers to a downstream project that
+      # depends on cloudpickle (for example: distributed, joblib, loky). For
+      # each project, a matrix item is created, that will run the $PROJECT
+      # test suite with the latest cloudpickle, to check for breaking changes
+      # introduced by cloudpickle.
+      # Side note: for distributed, the pytest major version is constrained to
+      # 3 because running it's test suite with pytest 4 fails for now. Also,
+      # two failing tests related to openssl and not to cloudpickle are
+      # skipped
+      python: 3.7
+      sudo: required
+      env: PROJECT=distributed
+           TEST_REQUIREMENTS="pytest==3.6 numpy pandas mock bokeh"
+           PROJECT_URL=https://github.com/dask/distributed.git
+           PYTEST_ARGS="-k not test_connection_args and not test_listen_args"
+      if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
+    - os: linux
+      env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"
+           PROJECT_URL=https://github.com/tomMoral/loky.git
+      python: 3.7
+      if: commit_message =~ /(\[ci downstream\]|\[ci loky\])/
+    - os: linux
+      env: PROJECT=joblib TEST_REQUIREMENTS="pytest numpy distributed"
+           PROJECT_URL=https://github.com/joblib/joblib.git
+      python: 3.7
+      if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
     - os: linux
       env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis"
            PROJECT_URL=https://github.com/ray-project/ray.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,9 @@ matrix:
       python: 3.7
       if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
     - os: linux
-      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil"
+      env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil flaky networkx tensorflow"
            PROJECT_URL=https://github.com/ray-project/ray.git
-           PYTEST_ARGS="--duration=10"
+           PYTEST_ARGS="--duration=10 --ignore=test_cython.py"
       python: 3.7
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ install:
             pip install ray;
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
-            cp cloudpickle/cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py;
+            cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py;
             PROJECT_DIR="$PROJECT_DIR/test";
         else
             pushd ..;

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,50 +3,50 @@ dist: xenial
 
 matrix:
   include:
-    - os: windows
-      language: sh
-      env: PYTHON_ROOT="/c/Python37" PYTHON_CHOCO_PKG="python3"
-    - os: windows
-      language: sh
-      env: PYTHON_ROOT="/c/Python27" PYTHON_CHOCO_PKG="python2"
-    - os: linux
-      dist: trusty
-      python: "pypy3"
-    - os: linux
-      python: 3.7
-    - os: linux
-      python: 3.6
-    - os: linux
-      python: 3.5
-    - os: linux
-      python: 2.7
-    - os: linux
-      # The PROJECT environment variable refers to a downstream project that
-      # depends on cloudpickle (for example: distributed, joblib, loky). For
-      # each project, a matrix item is created, that will run the $PROJECT
-      # test suite with the latest cloudpickle, to check for breaking changes
-      # introduced by cloudpickle.
-      # Side note: for distributed, the pytest major version is constrained to
-      # 3 because running it's test suite with pytest 4 fails for now. Also,
-      # two failing tests related to openssl and not to cloudpickle are
-      # skipped
-      python: 3.7
-      sudo: required
-      env: PROJECT=distributed
-           TEST_REQUIREMENTS="pytest==3.6 numpy pandas mock bokeh"
-           PROJECT_URL=https://github.com/dask/distributed.git
-           PYTEST_ARGS="-k not test_connection_args and not test_listen_args"
-      if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
-    - os: linux
-      env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"
-           PROJECT_URL=https://github.com/tomMoral/loky.git
-      python: 3.7
-      if: commit_message =~ /(\[ci downstream\]|\[ci loky\])/
-    - os: linux
-      env: PROJECT=joblib TEST_REQUIREMENTS="pytest numpy distributed"
-           PROJECT_URL=https://github.com/joblib/joblib.git
-      python: 3.7
-      if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
+    # - os: windows
+    #   language: sh
+    #   env: PYTHON_ROOT="/c/Python37" PYTHON_CHOCO_PKG="python3"
+    # - os: windows
+    #   language: sh
+    #   env: PYTHON_ROOT="/c/Python27" PYTHON_CHOCO_PKG="python2"
+    # - os: linux
+    #   dist: trusty
+    #   python: "pypy3"
+    # - os: linux
+    #   python: 3.7
+    # - os: linux
+    #   python: 3.6
+    # - os: linux
+    #   python: 3.5
+    # - os: linux
+    #   python: 2.7
+    # - os: linux
+    #   # The PROJECT environment variable refers to a downstream project that
+    #   # depends on cloudpickle (for example: distributed, joblib, loky). For
+    #   # each project, a matrix item is created, that will run the $PROJECT
+    #   # test suite with the latest cloudpickle, to check for breaking changes
+    #   # introduced by cloudpickle.
+    #   # Side note: for distributed, the pytest major version is constrained to
+    #   # 3 because running it's test suite with pytest 4 fails for now. Also,
+    #   # two failing tests related to openssl and not to cloudpickle are
+    #   # skipped
+    #   python: 3.7
+    #   sudo: required
+    #   env: PROJECT=distributed
+    #        TEST_REQUIREMENTS="pytest==3.6 numpy pandas mock bokeh"
+    #        PROJECT_URL=https://github.com/dask/distributed.git
+    #        PYTEST_ARGS="-k not test_connection_args and not test_listen_args"
+    #   if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
+    # - os: linux
+    #   env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"
+    #        PROJECT_URL=https://github.com/tomMoral/loky.git
+    #   python: 3.7
+    #   if: commit_message =~ /(\[ci downstream\]|\[ci loky\])/
+    # - os: linux
+    #   env: PROJECT=joblib TEST_REQUIREMENTS="pytest numpy distributed"
+    #        PROJECT_URL=https://github.com/joblib/joblib.git
+    #   python: 3.7
+    #   if: commit_message =~ /(\[ci downstream\]|\[ci joblib\])/
     - os: linux
       env: PROJECT=ray TEST_REQUIREMENTS="setproctitle hypothesis psutil flaky networkx tensorflow"
            PROJECT_URL=https://github.com/ray-project/ray.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
         - cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py
       script:
         - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
-        - pytest -vl --duration=10 $PROJECT_DIR/tests/test_mini.py
+        - pytest -vl --duration=10 $PROJECT_DIR/tests/test_basic.py
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,11 +57,10 @@ matrix:
         - PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")"
         - rm $PROJECT_DIR/cloudpickle/cloudpickle.py
         - cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py
-        - PROJECT_DIR="$PROJECT_DIR/tests"
         - pip list
       script:
         - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
-        - pytest -vl --duration=10 $PROJECT_DIR/test_mini.py
+        - pytest -vl --duration=10 $PROJECT_DIR/tests/test_mini.py
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,8 +97,8 @@ before_script:
 script:
   - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' pytest -r s
   - |
-    pushd $PROJECT_DIR
     if [[ $PROJECT != "" ]]; then
+      pushd $PROJECT_DIR
       # pytest hangs if given an empty quoted string (it will happen
       # if PYTEST_ARGS was not defined) so we have to split the cases.
       if [[ "$PYTEST_ARGS" != "" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,8 @@ install:
   - if [[ $PROJECT != "" ]]; then
         pip install $TEST_REQUIREMENTS;
         if [[ $PROJECT == "ray" ]]; then
-            wget https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev0-cp37-cp37m-manylinux1_x86_64.whl -O ray.whl;
-            pip install ray.whl;
+            wget https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.7.0.dev0-cp37-cp37m-manylinux1_x86_64.whl;
+            pip install ray-0.7.0.dev0-cp37-cp37m-manylinux1_x86_64.whl;
             PROJECT_DIR="$(python -c "import os,ray,sys;print(os.path.dirname(ray.__file__));sys.stdout.flush()")";
             rm $PROJECT_DIR/cloudpickle/cloudpickle.py;
             cp cloudpickle/cloudpickle.py $PROJECT_DIR/cloudpickle/cloudpickle.py;

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -260,6 +260,7 @@ class CloudPickler(Pickler):
         Pickler.__init__(self, file, protocol=protocol)
         # map ids to dictionary. used to ensure that functions can share global env
         self.globals_ref = {}
+        raise ValueError("Test Bug")
 
     def dump(self, obj):
         self.inject_addons()

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -260,7 +260,6 @@ class CloudPickler(Pickler):
         Pickler.__init__(self, file, protocol=protocol)
         # map ids to dictionary. used to ensure that functions can share global env
         self.globals_ref = {}
-        raise ValueError("Test Bug")
 
     def dump(self, obj):
         self.inject_addons()


### PR DESCRIPTION
Similar to #236, this pr adds the ability to test the development version cloudpickle against ray. 

Fixes #238 

@robertnishihara @ogrisel 