### PR TITLE
Fix downstream distributed CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,14 @@ matrix:
       # each project, a matrix item is created, that will run the $PROJECT
       # test suite with the latest cloudpickle, to check for breaking changes
       # introduced by cloudpickle.
-      # The tests ignored by the negative -k flag are known to also fail on
-      # the main dask distributed CI servers.
+      # The tests ignored by the negative -k flag are known to also be flaky on
+      # the main dask-distributed CI servers with stable versions of cloudpickle.
       python: 3.7
       sudo: required
       env: PROJECT=distributed
            TEST_REQUIREMENTS="pytest pytest-timeout numpy pandas mock bokeh"
            PROJECT_URL=https://github.com/dask/distributed.git
-           PYTEST_ADDOPTS="--timeout-method=thread --timeout=300 -m \"not avoid_travis\" -k \"not test_dask_scheduler and not test_defaults and not test_service_hosts and not test_logging_file_config\""
+           PYTEST_ADDOPTS="--timeout-method=thread --timeout=300 -m \"not avoid_travis\" -k \"not test_dask_scheduler and not test_defaults and not test_service_hosts and not test_logging_file_config and not test_hostport and not test_workdir_simple and not test_two_workspaces_in_same_directory\""
       if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
     - os: linux
       env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,16 +26,12 @@ matrix:
       # each project, a matrix item is created, that will run the $PROJECT
       # test suite with the latest cloudpickle, to check for breaking changes
       # introduced by cloudpickle.
-      # Side note: for distributed, the pytest major version is constrained to
-      # 3 because running it's test suite with pytest 4 fails for now. Also,
-      # two failing tests related to openssl and not to cloudpickle are
-      # skipped
       python: 3.7
       sudo: required
       env: PROJECT=distributed
-           TEST_REQUIREMENTS="pytest==3.6 numpy pandas mock bokeh"
+           TEST_REQUIREMENTS="pytest numpy pandas mock bokeh"
            PROJECT_URL=https://github.com/dask/distributed.git
-           PYTEST_ARGS="-k not test_connection_args and not test_listen_args"
+           PYTEST_ADDOPTS="-m \"not avoid_travis\""
       if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
     - os: linux
       env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"
@@ -85,13 +81,7 @@ script:
   - |
     if [[ $PROJECT != "" ]]; then
       pushd ../$PROJECT
-      # pytest hangs if given an empty quoted string (it will happen
-      # if PYTEST_ARGS was not defined) so we have to split the cases.
-      if [[ "$PYTEST_ARGS" != "" ]]; then
-        pytest -vl "$PYTEST_ARGS"
-      else
-        pytest -vl
-      fi
+      pytest -vl
       TEST_RETURN_CODE=$?
       popd
       if [[ "$TEST_RETURN_CODE" != "0" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       env: PROJECT=distributed
            TEST_REQUIREMENTS="pytest pytest-timeout numpy pandas mock bokeh"
            PROJECT_URL=https://github.com/dask/distributed.git
-           PYTEST_ADDOPTS="--timeout-method=thread --timeout=300 -m \"not avoid_travis\" -k \"not test_dask_scheduler and not test_defaults and not test_service_hosts and not test_logging_file_config and not test_hostport and not test_workdir_simple and not test_two_workspaces_in_same_directory\""
+           PYTEST_ADDOPTS="--timeout-method=thread --timeout=300 -m \"not avoid_travis\" -k \"not test_dask_scheduler and not test_defaults and not test_service_hosts and not test_logging_file_config and not test_hostport and not test_workdir_simple and not test_two_workspaces_in_same_directory and not test_recompute_released_results\""
       if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
     - os: linux
       env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       env: PROJECT=distributed
            TEST_REQUIREMENTS="pytest pytest-timeout numpy pandas mock bokeh"
            PROJECT_URL=https://github.com/dask/distributed.git
-           PYTEST_ADDOPTS="--timeout-method=thread --timeout=300 -m \"not avoid_travis\" -k \"not test_dask_scheduler and not test_defaults and not test_service_hosts and not test_logging_file_config and not test_hostport and not test_workdir_simple and not test_two_workspaces_in_same_directory and not test_recompute_released_results\""
+           PYTEST_ADDOPTS="--timeout-method=thread --timeout=300 -m \"not avoid_travis\" -k \"not test_dask_scheduler and not test_defaults and not test_service_hosts and not test_logging_file_config and not test_hostport and not test_workdir_simple and not test_two_workspaces_in_same_directory and not test_recompute_released_results and not test_connection_args and not test_listen_args\""
       if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
     - os: linux
       env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,14 @@ matrix:
       # each project, a matrix item is created, that will run the $PROJECT
       # test suite with the latest cloudpickle, to check for breaking changes
       # introduced by cloudpickle.
+      # The tests ignored by the negative -k flag are known to also fail on
+      # the main dask distributed CI servers.
       python: 3.7
       sudo: required
       env: PROJECT=distributed
            TEST_REQUIREMENTS="pytest numpy pandas mock bokeh"
            PROJECT_URL=https://github.com/dask/distributed.git
-           PYTEST_ADDOPTS="-m \"not avoid_travis\""
+           PYTEST_ADDOPTS="--timeout-method=thread --timeout=300 -m \"not avoid_travis\" -k \"not test_dask_scheduler and not test_defaults and not test_service_hosts and not test_logging_file_config\""
       if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
     - os: linux
       env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       python: 3.7
       sudo: required
       env: PROJECT=distributed
-           TEST_REQUIREMENTS="pytest numpy pandas mock bokeh"
+           TEST_REQUIREMENTS="pytest pytest-timeout numpy pandas mock bokeh"
            PROJECT_URL=https://github.com/dask/distributed.git
            PYTEST_ADDOPTS="--timeout-method=thread --timeout=300 -m \"not avoid_travis\" -k \"not test_dask_scheduler and not test_defaults and not test_service_hosts and not test_logging_file_config\""
       if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/


### PR DESCRIPTION
Use latest pytest for distributed tests + ignore avoid_travis marked tests.