### PR TITLE
Refactor builtin method pickling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+1.2.0
+=====
+
+- Support pickling of classmethod and staticmethod objects in python2.
+  arguments. ([issue #262](https://github.com/cloudpipe/cloudpickle/pull/262))
+
 1.1.0
 =====
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -805,16 +805,18 @@ class CloudPickler(Pickler):
     dispatch[type] = save_global
     dispatch[types.ClassType] = save_global
 
-    if not PY3:
-        def save_instancemethod(self, obj):
-            # Memoization rarely is ever useful due to python bounding
-            if obj.__self__ is None:
-                self.save_reduce(getattr, (obj.im_class, obj.__name__))
+    def save_instancemethod(self, obj):
+        # Memoization rarely is ever useful due to python bounding
+        if obj.__self__ is None:
+            self.save_reduce(getattr, (obj.im_class, obj.__name__))
+        else:
+            if PY3:  # pragma: no branch
+                self.save_reduce(types.MethodType, (obj.__func__, obj.__self__), obj=obj)
             else:
-                self.save_reduce(getattr, (obj.__self__, obj.__name__),
+                self.save_reduce(types.MethodType, (obj.__func__, obj.__self__, obj.__self__.__class__),
                                  obj=obj)
 
-        dispatch[types.MethodType] = save_instancemethod
+    dispatch[types.MethodType] = save_instancemethod
 
     def save_inst(self, obj):
         """Inner logic to save instance. Based off pickle.save_inst"""

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -747,7 +747,7 @@ class CloudPickler(Pickler):
                 return Pickler.save_global(self, obj)
 
             # obj is a method, such as dict.__new__ (from the builtin
-            # module) or itertools.chain.from_iterable (ffrom
+            # module) or itertools.chain.from_iterable (from
             # the itertools module).
             rv = (getattr, (obj.__self__, obj.__name__))
             return self.save_reduce(obj=obj, *rv)

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -788,18 +788,16 @@ class CloudPickler(Pickler):
     dispatch[type] = save_global
     dispatch[types.ClassType] = save_global
 
-    def save_instancemethod(self, obj):
-        # Memoization rarely is ever useful due to python bounding
-        if obj.__self__ is None:
-            self.save_reduce(getattr, (obj.im_class, obj.__name__))
-        else:
-            if PY3:  # pragma: no branch
-                self.save_reduce(types.MethodType, (obj.__func__, obj.__self__), obj=obj)
+    if not PY3:
+        def save_instancemethod(self, obj):
+            # Memoization rarely is ever useful due to python bounding
+            if obj.__self__ is None:
+                self.save_reduce(getattr, (obj.im_class, obj.__name__))
             else:
-                self.save_reduce(types.MethodType, (obj.__func__, obj.__self__, obj.__self__.__class__),
+                self.save_reduce(getattr, (obj.__self__, obj.__name__),
                                  obj=obj)
 
-    dispatch[types.MethodType] = save_instancemethod
+        dispatch[types.MethodType] = save_instancemethod
 
     def save_inst(self, obj):
         """Inner logic to save instance. Based off pickle.save_inst"""

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -754,6 +754,21 @@ class CloudPickler(Pickler):
 
         dispatch[types.BuiltinFunctionType] = save_builtin_function
 
+        def save_classmethod_descriptor(self, obj):
+            return self.save_reduce(getattr, (obj.__objclass__, obj.__name__))
+        classmethod_descriptor_type = type(float.__dict__['fromhex'])
+        dispatch[classmethod_descriptor_type] = save_classmethod_descriptor
+
+        def save_wrapper_descriptor(self, obj):
+            return self.save_reduce(getattr, (obj.__objclass__, obj.__name__))
+        wrapper_descriptor_type = type(float.__repr__)
+        dispatch[wrapper_descriptor_type] = save_wrapper_descriptor
+
+        def save_method_wrapper(self, obj):
+            return self.save_reduce(getattr, (obj.__self__, obj.__name__))
+        method_wrapper_type = type(1.5.__repr__)
+        dispatch[method_wrapper_type] = save_method_wrapper
+
     if sys.version_info[:2] < (3, 4):
         method_descriptor = type(str.upper)
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -738,7 +738,7 @@ class CloudPickler(Pickler):
         # Python3 comes with native reducers that allow builtin functions and
         # methods pickling as module/class attributes.  The following method
         # extends this for python2.
-        # Plase note that currently, neither pickle nor cloudpickle support
+        # Please note that currently, neither pickle nor cloudpickle support
         # dynamically created builtin functions/method pickling.
         def save_builtin_function_or_method(self, obj):
             is_bound = getattr(obj, '__self__', None) is not None
@@ -749,7 +749,7 @@ class CloudPickler(Pickler):
 
             is_unbound = hasattr(obj, '__objclass__')
             if is_unbound:
-                # obj is a unbound builtin method (accessed from its class)
+                # obj is an unbound builtin method (accessed from its class)
                 rv = (getattr, (obj.__objclass__, obj.__name__))
                 return self.save_reduce(obj=obj, *rv)
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -119,8 +119,10 @@ def _lookup_class_or_track(class_tracker_id, class_def):
 if PY3:
     from pickle import _getattribute
 else:
-    # compatibility function for python2 with the same signature as
-    # _getattribute
+    # pickle._getattribute is a python3 addition and enchancement of getattr,
+    # that can handle dotted attribute names. In cloudpickle for python2,
+    # handling dotted names is not needed, so we simply define _getattribute as
+    # a wrapper around getattr.
     def _getattribute(obj, name):
         return getattr(obj, name, None), None
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -653,6 +653,9 @@ class CloudPickleTest(unittest.TestCase):
         assert pickle_depickle(
             getcheckinterval, protocol=self.protocol) is getcheckinterval
 
+    @pytest.mark.skipif(platform.python_implementation() == 'PyPy' and
+                        sys.version_info[:2] == (3, 5),
+                        reason="bug of pypy3.5 in builtin constructors")
     def test_builtin_method(self):
         # Note that builtin_function_or_method are special-cased by cloudpickle
         # only in python2.

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -675,8 +675,8 @@ class CloudPickleTest(unittest.TestCase):
         # behaves as expected.
         self.assertEqual(list(fi_depickled([[1, 2], [3, 4]])), [1, 2, 3, 4])
 
-    # The next 4 tests pickle-depickle all forms into which builtin python
-    # methods can appear.
+    # The next 4 tests cover all cases into which builtin python methods can
+    # appear.
     # There are 4 kinds of method: 'classic' methods, classmethods,
     # staticmethods and slotmethods. They will appear under different types
     # depending on whether they are called from the __dict__ of their

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -694,12 +694,20 @@ class CloudPickleTest(unittest.TestCase):
         unbound_classicmethod = type(obj).hex  # method_descriptor
         clsdict_classicmethod = type(obj).__dict__['hex']  # method_descriptor
 
+        assert unbound_classicmethod is clsdict_classicmethod
+
         depickled_bound_meth = pickle_depickle(
             bound_classicmethod, protocol=self.protocol)
         depickled_unbound_meth = pickle_depickle(
             unbound_classicmethod, protocol=self.protocol)
         depickled_clsdict_meth = pickle_depickle(
             clsdict_classicmethod, protocol=self.protocol)
+
+        # No identity on the bound methods they are bound to different float
+        # instances
+        # assert depickled_bound_meth is bound_classicmethod
+        assert depickled_unbound_meth is unbound_classicmethod
+        assert depickled_clsdict_meth is clsdict_classicmethod
 
         assert depickled_bound_meth() == bound_classicmethod()
         assert depickled_unbound_meth(obj) == unbound_classicmethod(obj)
@@ -719,6 +727,10 @@ class CloudPickleTest(unittest.TestCase):
             unbound_clsmethod, protocol=self.protocol)
         depickled_clsdict_meth = pickle_depickle(
             clsdict_clsmethod, protocol=self.protocol)
+
+        # Identity on both the bound and the unbound methods cannot be
+        # tested: the bound methods are bound to different objects, and the
+        # unbound methods are actually recreated at each call.
 
         # classmethods may require objects of another type than the one they
         # are bound to.
@@ -755,6 +767,11 @@ class CloudPickleTest(unittest.TestCase):
         depickled_clsdict_meth = pickle_depickle(
             clsdict_slotmethod, protocol=self.protocol)
 
+        # No identity tests on the bound slotmethod are they are bound to
+        # different float instances
+        assert depickled_unbound_meth is unbound_slotmethod
+        assert depickled_clsdict_meth is clsdict_slotmethod
+
         assert depickled_bound_meth() == bound_slotmethod()
         assert depickled_unbound_meth(obj) == unbound_slotmethod(obj)
         assert depickled_clsdict_meth(obj) == clsdict_slotmethod(obj)
@@ -770,6 +787,8 @@ class CloudPickleTest(unittest.TestCase):
         unbound_staticmethod = type(obj).maketrans  # ditto
         clsdict_staticmethod = type(obj).__dict__['maketrans']  # staticmethod
 
+        assert bound_staticmethod is unbound_staticmethod
+
         depickled_bound_meth = pickle_depickle(
             bound_staticmethod, protocol=self.protocol)
         depickled_unbound_meth = pickle_depickle(
@@ -780,6 +799,9 @@ class CloudPickleTest(unittest.TestCase):
         # staticmethod may require objects of another type than the one they
         # are bound to.
         target = {"a": "b"}
+        assert depickled_bound_meth is bound_staticmethod
+        assert depickled_unbound_meth is unbound_staticmethod
+
         assert depickled_bound_meth(target) == bound_staticmethod(target)
         assert depickled_unbound_meth(target) == unbound_staticmethod(target)
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -732,8 +732,7 @@ class CloudPickleTest(unittest.TestCase):
         # tested: the bound methods are bound to different objects, and the
         # unbound methods are actually recreated at each call.
 
-        # classmethods may require objects of another type than the one they
-        # are bound to.
+        # float.fromhex takes a string as input.
         target = "0x1"
         assert depickled_bound_meth(target) == bound_clsmethod(target)
         assert depickled_unbound_meth(target) == unbound_clsmethod(target)
@@ -796,8 +795,7 @@ class CloudPickleTest(unittest.TestCase):
         depickled_clsdict_meth = pickle_depickle(
             clsdict_staticmethod, protocol=self.protocol)
 
-        # staticmethod may require objects of another type than the one they
-        # are bound to.
+        # str.maketrans takes a dict as input.
         target = {"a": "b"}
         assert depickled_bound_meth is bound_staticmethod
         assert depickled_unbound_meth is unbound_staticmethod

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -659,8 +659,8 @@ class CloudPickleTest(unittest.TestCase):
 
         # pickle_depickle some builtin methods of the __builtin__ module
         for t in list, tuple, set, frozenset, dict, object:
-            cloned = pickle_depickle(t.__new__, protocol=self.protocol)
-            self.assertTrue(cloned is t.__new__)
+            cloned_new = pickle_depickle(t.__new__, protocol=self.protocol)
+            assert isinstance(cloned_new(t), t)
 
         # pickle_depickle a method of a "regular" module
         fi = itertools.chain.from_iterable

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -722,11 +722,10 @@ class CloudPickleTest(unittest.TestCase):
         assert depickled_bound_meth(target) == bound_clsmethod(target)
         assert depickled_unbound_meth(target) == unbound_clsmethod(target)
 
-        # builtin classmethod_descriptor objects are not callable, neither do
-        # they have an accessible __func__ object. Moreover, roundtripping them
-        # results in a builtin_function_or_method (python upstream issue).
-        # XXX: shall we test anything in this case?
-        assert depickled_clsdict_meth == unbound_clsmethod
+        # Roundtripping a classmethod_descriptor results in a
+        # builtin_function_or_method (python upstream issue).
+        assert depickled_clsdict_meth(target) == clsdict_clsmethod(float,
+                                                                   target)
 
     def test_builtin_slotmethod(self):
         obj = 1.5  # float object

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -655,25 +655,16 @@ class CloudPickleTest(unittest.TestCase):
 
     @pytest.mark.skipif(platform.python_implementation() == 'PyPy' and
                         sys.version_info[:2] == (3, 5),
-                        reason="bug of pypy3.5 in builtin constructors")
-    def test_builtin_method(self):
-        # Note that builtin_function_or_method are special-cased by cloudpickle
-        # only in python2.
+                        reason="bug of pypy3.5 in builtin-type constructors")
+    def test_builtin_type_constructor(self):
+        # Due to a bug in pypy3.5, cloudpickling builtin-type constructors
+        # fails. This test makes sure that cloudpickling builtin-type
+        # constructors works for all other python versions/implementation.
 
         # pickle_depickle some builtin methods of the __builtin__ module
         for t in list, tuple, set, frozenset, dict, object:
             cloned_new = pickle_depickle(t.__new__, protocol=self.protocol)
             assert isinstance(cloned_new(t), t)
-
-        # pickle_depickle a method of a "regular" module
-        fi = itertools.chain.from_iterable
-        fi_depickled = pickle_depickle(fi, protocol=self.protocol)
-
-        # `fi is fi_depickled` would return False, but so will
-        # `itertools.chain.from_iterable is itertools.chain.from_iterable`.
-        # Instead of testing physical equality, check that `fi_depickled`
-        # behaves as expected.
-        self.assertEqual(list(fi_depickled([[1, 2], [3, 4]])), [1, 2, 3, 4])
 
     # The next 4 tests cover all cases into which builtin python methods can
     # appear.

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -726,19 +726,18 @@ class CloudPickleTest(unittest.TestCase):
             clsdict_clsmethod, protocol=self.protocol)
 
         # float.fromhex takes a string as input.
-        target = "0x1"
+        arg = "0x1"
 
         # Identity on both the bound and the unbound methods cannot be
         # tested: the bound methods are bound to different objects, and the
         # unbound methods are actually recreated at each call.
-        assert depickled_bound_meth(target) == bound_clsmethod(target)
-        assert depickled_unbound_meth(target) == unbound_clsmethod(target)
+        assert depickled_bound_meth(arg) == bound_clsmethod(arg)
+        assert depickled_unbound_meth(arg) == unbound_clsmethod(arg)
 
         if platform.python_implementation() == 'CPython':
             # Roundtripping a classmethod_descriptor results in a
             # builtin_function_or_method (CPython upstream issue).
-            assert depickled_clsdict_meth(target) == clsdict_clsmethod(float,
-                                                                       target)
+            assert depickled_clsdict_meth(arg) == clsdict_clsmethod(float, arg)
         if platform.python_implementation() == 'PyPy':
             # builtin-classmethods are simple classmethod in PyPy (not
             # callable). We test equality of types and the functionality of the
@@ -747,7 +746,7 @@ class CloudPickleTest(unittest.TestCase):
             # pickleable and must be reconstructed at depickling time.
             assert type(depickled_clsdict_meth) == type(clsdict_clsmethod)
             assert depickled_clsdict_meth.__func__(
-                float, target) == clsdict_clsmethod.__func__(float, target)
+                float, arg) == clsdict_clsmethod.__func__(float, arg)
 
     def test_builtin_slotmethod(self):
         obj = 1.5  # float object
@@ -788,9 +787,6 @@ class CloudPickleTest(unittest.TestCase):
             unbound_staticmethod, protocol=self.protocol)
         depickled_clsdict_meth = pickle_depickle(
             clsdict_staticmethod, protocol=self.protocol)
-
-        # str.maketrans takes a dict as input.
-        target = {"a": "b"}
 
         assert depickled_bound_meth is bound_staticmethod
         assert depickled_unbound_meth is unbound_staticmethod

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -641,10 +641,10 @@ class CloudPickleTest(unittest.TestCase):
         res = pickle_depickle(type(NotImplemented), protocol=self.protocol)
         self.assertEqual(type(NotImplemented), res)
 
-    @pytest.mark.skipif(
-        sys.version_info[0] >= 3,
-        reason="builtin_function_or_method are special-cased only in python2")
     def test_builtin_function(self):
+        # Note that builtin_function_or_method are special-cased by cloudpickle
+        # only in python2.
+
         # builtin function from the __builtin__ module
         assert pickle_depickle(zip, protocol=self.protocol) is zip
 
@@ -653,10 +653,10 @@ class CloudPickleTest(unittest.TestCase):
         assert pickle_depickle(
             getcheckinterval, protocol=self.protocol) is getcheckinterval
 
-    @pytest.mark.skipif(
-        sys.version_info[0] >= 3,
-        reason="builtin_function_or_method are special-cased only in python2")
     def test_builtin_method(self):
+        # Note that builtin_function_or_method are special-cased by cloudpickle
+        # only in python2.
+
         # pickle_depickle some builtin methods of the __builtin__ module
         for t in list, tuple, set, frozenset, dict, object:
             cloned = pickle_depickle(t.__new__, protocol=self.protocol)
@@ -666,8 +666,10 @@ class CloudPickleTest(unittest.TestCase):
         fi = itertools.chain.from_iterable
         fi_depickled = pickle_depickle(fi, protocol=self.protocol)
 
-        # fi is fi_depickled will return false, but so does
-        # itertools.chain.from_iterable is itertools.chain.from_iterable
+        # `fi is fi_depickled` would return False, but so will
+        # `itertools.chain.from_iterable is itertools.chain.from_iterable`.
+        # Instead of testing physical equality, check that `fi_depickled`
+        # behaves as expected.
         self.assertEqual(list(fi_depickled([[1, 2], [3, 4]])), [1, 2, 3, 4])
 
     @pytest.mark.skipif(tornado is None,


### PR DESCRIPTION
The way `cloudpickle` handles `builtin_function_or_method` is very confusing for many reasons:

- it does not explicitly separate the cases between builtin_function and builtin_methods.
- it interleaves `builtin_function_or_method` handling with more classic function handling
- it special-cases things that do not need to be special-cases, such as builtin types constructors.

In realilty, things are not that complex:

- `builtin_function_or_method` are correctly handled by the standard pickle in python3, so we do not need to special case them AT ALL in python3
- in python2, builtin functions are picklable. We only need to special-case builtin methods.
 
This PR addresses all the previously stated issues: it separates clearly `builtin_function_or_method` from classic functions, add a special case only for builtin_method in python2, and as a consequence, removes a lot of obscure special-cases.