### PR TITLE
Add CLOUDPICKLE_DEFAULT_PROTOCOL env to control the default pickle protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
       python: 3.7
     - os: linux
       python: 3.6
+      env: CLOUDPICKLE_DEFAULT_PROTOCOL=3
     - os: linux
       python: 3.5
     - os: linux

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -50,6 +50,7 @@ import itertools
 import logging
 import opcode
 import operator
+import os
 import pickle
 import struct
 import sys
@@ -60,7 +61,7 @@ import weakref
 # cloudpickle is meant for inter process communication: we expect all
 # communicating processes to run the same Python version hence we favor
 # communication speed over compatibility:
-DEFAULT_PROTOCOL = pickle.HIGHEST_PROTOCOL
+DEFAULT_PROTOCOL = int(os.environ.get("CLOUDPICKLE_DEFAULT_PROTOCOL", pickle.HIGHEST_PROTOCOL))
 
 
 if sys.version_info[0] < 3:  # pragma: no branch


### PR DESCRIPTION
This PR proposes to add an env `CLOUDPICKLE_DEFAULT_PROTOCOL` for users to set the default protocol.

Few issues were found after Spark side upgrades cloudpickle from 0.4 to 0.8. Other issues were fixed but one issue is (I suspect) in Pyrolite or at least it's related. Spark uses Pyrolite to unpickle Python objects in JVM and looks Pyrolite has a bug when to unpickle lists (see SPARK-27612).

For clarification, I want this env as an internal purpose for now and see if this actually brings some overhead for dev. If it doesn't, I would like to keep this env. If it does, let's drop this env.