### PR TITLE
MNT integrate `pickle.save_global` logic in cloudpickle natively

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -1299,7 +1299,7 @@ def _is_dynamic(module):
         # __spec__ attribute set to None despite being imported.  For such
         # modules, the ``_find_spec`` utility of the standard library is used.
         parent_name = module.__name__.rpartition('.')[0]
-        if parent_name:  # pragma: no branch
+        if parent_name:  # pragma: no cover
             # This code handles the case where an imported package (and not
             # module) remains with __spec__ set to None. It is however untested
             # as no package in the PyPy stdlib has __spec__ set to None after

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -93,11 +93,7 @@ else:
     string_types = (str,)
     PY3 = True
     PY2 = False
-
-    if platform.python_implementation() == 'PyPy':
-        from importlib._bootstrap import _find_spec
-    else:
-        from _frozen_importlib import _find_spec
+    from importlib._bootstrap import _find_spec
 
 
 def _ensure_tracking(class_def):
@@ -180,8 +176,8 @@ def _is_global(obj, name=None):
         # supported, as the standard pickle does not support it either.
         return False
 
+    # module has been added to sys.modules, but it can still be dynamic.
     if _is_dynamic(module):
-        # module has been added to sys.modules, but it can still be dynamic.
         return False
 
     try:
@@ -189,9 +185,7 @@ def _is_global(obj, name=None):
     except AttributeError:
         # obj was not found inside the module it points to
         return False
-    if obj2 is not obj:
-        return False
-    return True
+    return obj2 is obj
 
 
 def _make_cell_set_template_code():

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -125,10 +125,10 @@ else:
         return getattr(obj, name, None), None
 
 
-def whichmodule(obj, name):
+def _whichmodule(obj, name):
     """Find the module an object belongs to.
 
-    This function differs from ``pickle.whichmodule`` in two ways:
+    This function differs from ``pickle._whichmodule`` in two ways:
     - it does not mangle the cases where obj's module is __main__ and obj was
       not found in any module.
     - Errors arising during module introspection are ignored, as those errors
@@ -157,7 +157,7 @@ def _is_global(obj, name=None):
     if name is None:
         name = getattr(obj, '__name__', None)
 
-    module_name = whichmodule(obj, name)
+    module_name = _whichmodule(obj, name)
 
     if module_name is None:
         # In this case, obj.__module__ is None AND obj was not found in any

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -813,6 +813,8 @@ class CloudPickler(Pickler):
         elif obj in _BUILTIN_TYPE_NAMES:
             return self.save_reduce(
                 _builtin_type, (_BUILTIN_TYPE_NAMES[obj],), obj=obj)
+        elif name is not None:
+            Pickler.save_global(self, obj, name=name)
         elif not _is_global(obj, name=name):
             self.save_dynamic_class(obj)
         else:

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -50,6 +50,7 @@ import logging
 import opcode
 import operator
 import pickle
+import platform
 import struct
 import sys
 import traceback
@@ -93,7 +94,7 @@ else:
     PY3 = True
     PY2 = False
 
-    if sys.implementation.name == 'pypy':
+    if platform.python_implementation() == 'PyPy':
         from importlib._bootstrap import _find_spec
     else:
         from _frozen_importlib import _find_spec

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -128,7 +128,7 @@ else:
 def _whichmodule(obj, name):
     """Find the module an object belongs to.
 
-    This function differs from ``pickle._whichmodule`` in two ways:
+    This function differs from ``pickle.whichmodule`` in two ways:
     - it does not mangle the cases where obj's module is __main__ and obj was
       not found in any module.
     - Errors arising during module introspection are ignored, as those errors

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -1299,7 +1299,11 @@ def _is_dynamic(module):
         # __spec__ attribute set to None despite being imported.  For such
         # modules, the ``_find_spec`` utility of the standard library is used.
         parent_name = module.__name__.rpartition('.')[0]
-        if parent_name:
+        if parent_name:  # pragma: no branch
+            # This code handles the case where an imported package (and not
+            # module) remains with __spec__ set to None. It is however untested
+            # as no package in the PyPy stdlib has __spec__ set to None after
+            # it is imported.
             try:
                 parent = sys.modules[parent_name]
             except KeyError:

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -307,10 +307,6 @@ HAVE_ARGUMENT = dis.HAVE_ARGUMENT
 EXTENDED_ARG = dis.EXTENDED_ARG
 
 
-def islambda(func):
-    return getattr(func, '__name__') == '<lambda>'
-
-
 _BUILTIN_TYPE_NAMES = {}
 for k, v in types.__dict__.items():
     if type(v) is type:
@@ -1092,13 +1088,6 @@ def dynamic_subimport(name, vars):
     mod = types.ModuleType(name)
     mod.__dict__.update(vars)
     return mod
-
-
-# restores function attributes
-def _restore_attr(obj, attr):
-    for key, val in attr.items():
-        setattr(obj, key, val)
-    return obj
 
 
 def _gen_ellipsis():

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -478,6 +478,10 @@ class CloudPickleTest(unittest.TestCase):
         mod1, mod2 = pickle_depickle([mod, mod])
         self.assertEqual(id(mod1), id(mod2))
 
+        # Test pickling a function of mod
+        depickled_f = pickle_depickle(mod.f, protocol=self.protocol)
+        self.assertEqual(mod.f(5), depickled_f(5))
+
     def test_module_locals_behavior(self):
         # Makes sure that a local function defined in another module is
         # correctly serialized. This notably checks that the globals are

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -478,9 +478,14 @@ class CloudPickleTest(unittest.TestCase):
         mod1, mod2 = pickle_depickle([mod, mod])
         self.assertEqual(id(mod1), id(mod2))
 
-        # Test pickling a function of mod
-        depickled_f = pickle_depickle(mod.f, protocol=self.protocol)
-        self.assertEqual(mod.f(5), depickled_f(5))
+        # Ensure proper pickling of mod's functions when module "looks" like a
+        # file-backed module even though it is not:
+        try:
+            sys.modules['mod'] = mod
+            depickled_f = pickle_depickle(mod.f, protocol=self.protocol)
+            self.assertEqual(mod.f(5), depickled_f(5))
+        finally:
+            sys.modules.pop('mod', None)
 
     def test_module_locals_behavior(self):
         # Makes sure that a local function defined in another module is

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -621,7 +621,7 @@ class CloudPickleTest(unittest.TestCase):
         dynamic_module = types.ModuleType('dynamic_module')
         assert _is_dynamic(dynamic_module)
 
-        if sys.implementation.name == 'pypy':
+        if platform.python_implementation() == 'PyPy':
             import _codecs
             assert not _is_dynamic(_codecs)
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -621,6 +621,10 @@ class CloudPickleTest(unittest.TestCase):
         dynamic_module = types.ModuleType('dynamic_module')
         assert _is_dynamic(dynamic_module)
 
+        if sys.implementation.name == 'pypy':
+            import _codecs
+            assert not _is_dynamic(_codecs)
+
     def test_Ellipsis(self):
         self.assertEqual(Ellipsis,
                          pickle_depickle(Ellipsis, protocol=self.protocol))

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1798,6 +1798,15 @@ class CloudPickleTest(unittest.TestCase):
         """.format(protocol=self.protocol)
         assert_run_python_script(textwrap.dedent(code))
 
+    def test___reduce___returns_string(self):
+        # Non regression test for objects with a __reduce__ method returning a
+        # string, meaning "save by attribute using save_global"
+        from .mypkg import some_singleton
+        assert some_singleton.__reduce__() == "some_singleton"
+        depickled_singleton = pickle_depickle(
+            some_singleton, protocol=self.protocol)
+        assert depickled_singleton is some_singleton
+
 class Protocol2CloudPickleTest(CloudPickleTest):
 
     protocol = 2

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1023,7 +1023,7 @@ class CloudPickleTest(unittest.TestCase):
         self.assertEqual(set(weakset), {depickled1, depickled2})
 
     def test_faulty_module(self):
-        for module_name in ['_faulty_module', '_missing_module', None]:
+        for module_name in ['_missing_module', None]:
             class FaultyModule(object):
                 def __getattr__(self, name):
                     # This throws an exception while looking up within

--- a/tests/mypkg/__init__.py
+++ b/tests/mypkg/__init__.py
@@ -4,3 +4,12 @@ from .mod import module_function
 def package_function():
     """Function living inside a package, not a simple module"""
     return "hello from a package!"
+
+
+class _SingletonClass(object):
+    def __reduce__(self):
+        # This reducer is only valid for the top level "some_singleton" object.
+        return "some_singleton"
+
+
+some_singleton = _SingletonClass()


### PR DESCRIPTION
This PR solves #261. It is also preparation work for #253 .

## Preparation work for #253
Previously, checking if a class was pickleable was done by:
```python
try:
    Pickler.save_global(self, obj, name=name)  # call pickle._Pickler.save_global
except Exception:
    # obj is not pickleable
    ... 
```

We cannot do that in #272 as `save_global` is not an accessible method of the `C` accelerated `Pickler`. We could do
```python
try:
    pickle.dumps(obj)
except Exception:
   ...
```
But this is quite costly as it recreates a `Pickler` from scratch.


Instead, we can re-write the logic of `_Pickler.save_global` into cloudpickle. It was partially already there in `cloudpickle.Cloudpickler.save_function`. I extracted this logic in a new `_is_global` helper. Also, I used it both for classes and functions, because the difference is not made in `pickle.Pickler.save_global`: both of those types are treated as global.

## Solving #261 
Now that the pickling logic of `save_global` is natively implemented in `cloudpickle`, we can handle exceptions at a finer grain. Especially, we can ignore Exceptions coming from unrelated modules when resolving an object's module attribute path, while not ignoring Errors coming from the object's actual module.

## More cleanups

I also removed some unreachable code in `save_function`. 
[These spreadsheets](https://github.com/cloudpipe/cloudpickle/files/3203217/pg.pdf) split down all possible use-cases into 4 subspaces. The number are, for each subspace, the line at which `save_function` returns. In any subspace, `save_function` exits at a line preceding these lines:
 https://github.com/cloudpipe/cloudpickle/blob/61761935ff0b101784534747679ce88a1c9d617a/cloudpickle/cloudpickle.py#L440-L449  So it is safe to remove them.
