### PR TITLE
Fix for CloudPickle Dropping Type Hints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 - Support pickling of classmethod and staticmethod objects in python2.
   arguments. ([issue #262](https://github.com/cloudpipe/cloudpickle/pull/262))
 
+- Fix for CloudPickle Dropping Type Hints ([issue #276](https://github.com/cloudpipe/cloudpickle/pull/276))
+
 1.1.1
 =====
 
@@ -77,7 +79,7 @@
 - Stop using the deprecated `imp` module under Python 3.
   ([issue #207](https://github.com/cloudpipe/cloudpickle/issues/207))
 
-- Fixed pickling issue with singleton types `NoneType`, `type(...)` and 
+- Fixed pickling issue with singleton types `NoneType`, `type(...)` and
   `type(NotImplemented)` ([issue #209](https://github.com/cloudpipe/cloudpickle/issues/209))
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,10 @@
 - Support pickling of classmethod and staticmethod objects in python2.
   arguments. ([issue #262](https://github.com/cloudpipe/cloudpickle/pull/262))
 
-- Fix for CloudPickle Dropping Type Hints ([issue #276](https://github.com/cloudpipe/cloudpickle/pull/276))
+- Add support to pickle type annotations for Python 3.5 and 3.6 (pickling type
+  annotations was already supported for Python 3.7, Python 3.4 might also work
+  but is no longer officially supported by cloudpickle)
+  ([issue #276](https://github.com/cloudpipe/cloudpickle/pull/276))
 
 1.1.1
 =====

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -657,7 +657,7 @@ class CloudPickler(Pickler):
             'name': func.__name__,
             'doc': func.__doc__,
         }
-        if hasattr(func, '__annotations__') and sys.version_info >= (3, 7):
+        if hasattr(func, '__annotations__') and sys.version_info >= (3, 4):
             state['annotations'] = func.__annotations__
         if hasattr(func, '__qualname__'):
             state['qualname'] = func.__qualname__

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1590,7 +1590,7 @@ class CloudPickleTest(unittest.TestCase):
 
     @unittest.skipIf(sys.version_info < (3, 4),
                      """This syntax won't work on py2 and pickling annotations
-                     isn't supported for py36 and below.""")
+                     isn't supported for py34 and below.""")
     def test_wraps_preserves_function_annotations(self):
         from functools import wraps
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1588,7 +1588,7 @@ class CloudPickleTest(unittest.TestCase):
 
         self.assertEqual(f2.__doc__, f.__doc__)
 
-    @unittest.skipIf(sys.version_info < (3, 7),
+    @unittest.skipIf(sys.version_info < (3, 4),
                      """This syntax won't work on py2 and pickling annotations
                      isn't supported for py36 and below.""")
     def test_wraps_preserves_function_annotations(self):


### PR DESCRIPTION
- Adds fix in if logic so typings are captured for older versions of python.

This resolves issue: https://github.com/cloudpipe/cloudpickle/issues/171
