### PR TITLE
MNT mention #273 improvements in the changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,8 +9,9 @@
   but is no longer officially supported by cloudpickle)
   ([issue #276](https://github.com/cloudpipe/cloudpickle/pull/276))
 
-- Internal refactoring of the pickling logic to make the code more predictable.
-  This refactoring also yielded small performance improvements (~10%)
+- Internal refactoring to proactively detect dynamic functions and classes when
+  pickling them.  This refactoring also yields small performance improvements
+  when pickling dynamic classes (~10%)
   ([issue #273](https://github.com/cloudpipe/cloudpickle/pull/273))
 
 1.1.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@
   but is no longer officially supported by cloudpickle)
   ([issue #276](https://github.com/cloudpipe/cloudpickle/pull/276))
 
+- Internal refactoring of the pickling logic to make the code more predictable.
+  This refactoring also yielded small performance improvements (~10%)
+  ([issue #273](https://github.com/cloudpipe/cloudpickle/pull/273))
+
 1.1.1
 =====
 

--- a/cloudpickle/__init__.py
+++ b/cloudpickle/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from cloudpickle.cloudpickle import *
 
-__version__ = '1.1.1'
+__version__ = '1.2.0.dev0'


### PR DESCRIPTION
Pickling classes - try for example with this script:
```python
import cloudpickle


class A:
    pass


cloudpickle.dumps(A)
```

is now slightly faster (~10%) thanks to #273, so it is worth mentioning it in the changelog.