### PR TITLE
Fix restore partial python 3.4 compat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+
+1.2.1
+=====
+
+- Restore (partial) support for Python 3.4 for downstream projects that have
+  LTS versions that would benefit from cloudpickle bug fixes.
+
+
 1.2.0
 =====
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -123,8 +123,13 @@ def _lookup_class_or_track(class_tracker_id, class_def):
             _DYNAMIC_CLASS_TRACKER_BY_CLASS[class_def] = class_tracker_id
     return class_def
 
-if PY3:
+if sys.version_info[:2] >= (3, 5):
     from pickle import _getattribute
+elif sys.version_info[:2] >= (3, 4):
+    from pickle import _getattribute as _py34_getattribute
+    #  pickle._getattribute does not return the parent under Python 3.4
+    def _getattribute(obj, name):
+        return _py34_getattribute(obj, name), None
 else:
     # pickle._getattribute is a python3 addition and enchancement of getattr,
     # that can handle dotted attribute names. In cloudpickle for python2,

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1658,6 +1658,8 @@ class CloudPickleTest(unittest.TestCase):
         pickle_depickle(DataClass, protocol=self.protocol)
         assert data.x == pickle_depickle(data, protocol=self.protocol).x == 42
 
+    @unittest.skipIf(sys.version_info[:2] < (3, 5),
+                     "Only support enum pickling on Python 3.5+")
     def test_locally_defined_enum(self):
         enum = pytest.importorskip("enum")
 
@@ -1689,6 +1691,8 @@ class CloudPickleTest(unittest.TestCase):
         green3 = pickle_depickle(Color.GREEN, protocol=self.protocol)
         assert green3 is Color.GREEN
 
+    @unittest.skipIf(sys.version_info[:2] < (3, 5),
+                     "Only support enum pickling on Python 3.5+")
     def test_locally_defined_intenum(self):
         enum = pytest.importorskip("enum")
         # Try again with a IntEnum defined with the functional API
@@ -1703,6 +1707,8 @@ class CloudPickleTest(unittest.TestCase):
         assert green1 is not ClonedDynamicColor.BLUE
         assert ClonedDynamicColor is DynamicColor
 
+    @unittest.skipIf(sys.version_info[:2] < (3, 5),
+                     "Only support enum pickling on Python 3.5+")
     def test_interactively_defined_enum(self):
         pytest.importorskip("enum")
         code = """if __name__ == "__main__":


### PR DESCRIPTION
Useful for loky, joblib and scikit-learn 0.20.x in particular.