### PR TITLE
Revert type hints support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 1.2.2
 =====
 
+- Revert the change introduced in
+  ([issue #276](https://github.com/cloudpipe/cloudpickle/pull/276))
+  attempting to pickle functions annotations for Python 3.4 to 3.6. It is not
+  possible to pickle complex typing constructs for those versions (see
+  [issue #193]( https://github.com/cloudpipe/cloudpickle/issues/193))
+
 - Fix a bug affecting bound classmethod saving on Python 2.
   ([issue #288](https://github.com/cloudpipe/cloudpickle/issues/288))
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ Running the tests
 Note about function Annotations
 -------------------------------
 
-Note that because of design issues `Python`'s `typing` module, `cloudpickle` will
-not pickle dynamic function annotations on `Python` 3.4, 3.5 and 3.6:
+Note that because of design issues `Python`'s `typing` module, `cloudpickle`
+supports pickling type annotations of dynamic functions for `Python` 3.7 and
+later.  On `Python` 3.4, 3.5 and 3.6, those type annotations will be dropped
+silently during pickling (example below):
 
 ```python
 >>> import typing

--- a/README.md
+++ b/README.md
@@ -85,6 +85,23 @@ Running the tests
       PYTHONPATH='.:tests' py.test
 
 
+Note about function Annotations
+-------------------------------
+
+Note that because of design issues `Python`'s `typing` module, `cloudpickle` will
+not pickle dynamic function annotations on `Python` 3.4, 3.5 and 3.6:
+
+```python
+>>> import typing
+>>> import cloudpickle
+>>> def f(x: typing.Union[list, int]):
+...     return x
+>>> f
+<function __main__.f(x:Union[list, int])>
+>>> cloudpickle.loads(cloudpickle.dumps(f))  # drops f's annotations
+<function __main__.f(x)>
+```
+
 History
 -------
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -747,7 +747,9 @@ class CloudPickler(Pickler):
             'doc': func.__doc__,
             '_cloudpickle_submodules': submodules
         }
-        if hasattr(func, '__annotations__') and sys.version_info >= (3, 4):
+        if hasattr(func, '__annotations__') and sys.version_info >= (3, 7):
+            # Although annotations were added in Python3.4, It is not possible
+            # to properly pickle them until Python3.7. (See #193)
             state['annotations'] = func.__annotations__
         if hasattr(func, '__qualname__'):
             state['qualname'] = func.__qualname__

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1650,7 +1650,6 @@ class CloudPickleTest(unittest.TestCase):
         t = typing.Union[list, int]
         assert pickle_depickle(t) == t
 
-
     def test_instance_with_slots(self):
         for slots in [["registered_attribute"], "registered_attribute"]:
             class ClassWithSlots(object):

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1622,8 +1622,8 @@ class CloudPickleTest(unittest.TestCase):
         self.assertEqual(f2.__doc__, f.__doc__)
 
     @unittest.skipIf(sys.version_info < (3, 7),
-                     """This syntax won't work on py2 and pickling annotations
-                     isn't supported for py37 and below.""")
+                     "This syntax won't work on py2 and pickling annotations "
+                     "isn't supported for py37 and below.")
     def test_wraps_preserves_function_annotations(self):
         from functools import wraps
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1621,9 +1621,9 @@ class CloudPickleTest(unittest.TestCase):
 
         self.assertEqual(f2.__doc__, f.__doc__)
 
-    @unittest.skipIf(sys.version_info < (3, 4),
+    @unittest.skipIf(sys.version_info < (3, 7),
                      """This syntax won't work on py2 and pickling annotations
-                     isn't supported for py34 and below.""")
+                     isn't supported for py37 and below.""")
     def test_wraps_preserves_function_annotations(self):
         from functools import wraps
 
@@ -1639,6 +1639,17 @@ class CloudPickleTest(unittest.TestCase):
         f2 = pickle_depickle(g, protocol=self.protocol)
 
         self.assertEqual(f2.__annotations__, f.__annotations__)
+
+    @unittest.skipIf(sys.version_info < (3, 7),
+                     """This syntax won't work on py2 and pickling annotations
+                     isn't supported for py37 and below.""")
+    def test_type_hint(self):
+        # Try to pickle compound typing constructs. This would typically fail
+        # on Python < 3.7 (See #193)
+        import typing
+        t = typing.Union[list, int]
+        assert pickle_depickle(t) == t
+
 
     def test_instance_with_slots(self):
         for slots in [["registered_attribute"], "registered_attribute"]:


### PR DESCRIPTION
Following https://github.com/cloudpipe/cloudpickle/issues/298#issuecomment-512085092, we need to revert the support for pickling annotation in Python3.4-3.6 introduced in #276 . Pickling annotations on those versions was a known issue (#193) , but I was not aware of it when #276 got merged. 
I added a note in the readme, as well as some comments in the code to make it clear why we start supporting annotations from 3.7 whereas they were introduced in python3.4.