### PR TITLE
make test_builtin_function use a cross-version function

### DIFF
--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -670,10 +670,9 @@ class CloudPickleTest(unittest.TestCase):
         # builtin function from the __builtin__ module
         assert pickle_depickle(zip, protocol=self.protocol) is zip
 
-        from sys import getcheckinterval
+        from os import mkdir
         # builtin function from a "regular" module
-        assert pickle_depickle(
-            getcheckinterval, protocol=self.protocol) is getcheckinterval
+        assert pickle_depickle(mkdir, protocol=self.protocol) is mkdir
 
     @pytest.mark.skipif(platform.python_implementation() == 'PyPy' and
                         sys.version_info[:2] == (3, 5),


### PR DESCRIPTION
`test_builtin_function` used to pickle `sys.getcheckinterval`, which was removed in python 3.9 following: https://bugs.python.org/issue37392, making the `python-nighly` build of cloudpickle's CI fail. This PR changes the usage of `getcheckinterval` to `os.mkdir` (arbitrary)