### PR TITLE
update cloudpickle CI for python3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,12 @@ matrix:
       python: "pypy3"
     - os: linux
       env: PYTHON_NIGHTLY=1
+      if: commit_message =~ /\[ci python-nightly\]/
       python: 3.7
     - os: linux
       python: 3.7
+    - os: linux
+      python: "3.8-dev"
     - os: linux
       python: 3.6
     - os: linux
@@ -91,12 +94,8 @@ install:
   - $PYTHON_EXE -m pip install .
   - $PYTHON_EXE -m pip install --upgrade -r dev-requirements.txt
   - $PYTHON_EXE -m pip install tornado
-  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
-        if [[ "$PYTHON_NIGHTLY" == "1" ]]; then
-          $PYTHON_EXE -m pip install git+https://github.com/cython/cython git+https://github.com/numpy/numpy;
-        else
+  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* && "$PYTHON_NIGHTLY" != "1" ]]; then
           $PYTHON_EXE -m pip install numpy scipy;
-        fi
     fi
   - if [[ $PROJECT != "" ]]; then
         $PYTHON_EXE -m pip install $TEST_REQUIREMENTS;


### PR DESCRIPTION
Previously, travis `python3.8-dev` entry was the `3.8` alpha release, which did not include some features we needed to correctly test `cloudpickle_fast` -- to test `cloudpickle_fast` against new `3.8` versions, we thus used to build `Python` from source. 

Travis should have updated it's entry to the `Python3.8 beta` release by now. So we don't need to build python from source for 3.8. But testing cloudpickle against a nightly build of Python is still useful to spot bugs early, so I made this triggerable when `ci python-nightly` is present in the commit message.