### PR TITLE
WIP: Support pickling lru_cache on CPython

### DIFF
--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1876,7 +1876,8 @@ class CloudPickleTest(unittest.TestCase):
         with pytest.raises(pickle.PicklingError, match='recursion'):
             cloudpickle.dumps(a)
 
-    @unittest.skipIf(not hasattr(functools, "lru_cache"),
+    @unittest.skipIf(not hasattr(functools, "lru_cache")
+                     or platform.python_implementation() == 'PyPy',
                      "Old versions of Python do not have lru_cache.")
     def test_pickle_lru_cached_function(self):
 


### PR DESCRIPTION
I was poking through the issue tracker over the weekend and noticed https://github.com/cloudpipe/cloudpickle/issues/178. This is an initial pass on what I think is feasible to support without aggressive hackery:

TL;DR:

- This PR enables support for pickling functions decorated with `lru_cache` on CPython.
- This PR does **not** pickle an `lru_cache`d function's associated cache.
- This PR preserves the value of `cached_func.maxsize`, but **loses** the value of `typed` that was passed to the cached function. I don't think `typed` is used very often, but it seems unfortunate that this PR silently discards that info. I don't have a good idea for how to fix that without upstream changes in CPython.
- This PR doesn't change the current behavior on PyPy which is to just deep-serialize the entire function closure, including the cache. It's unclear to me whether we should be willing to pay an extra runtime cost (though, admittedly, a pretty trivial one) to make this behavior consistent.

---

Following @ogrisel's comment in https://github.com/cloudpipe/cloudpickle/issues/178#issuecomment-466468488, we can support simple usage of `lru_cache` in CPython straightforwardly, because lru-cached functions are instances of an extension type that provides enough of an API (via `.__wrapped__` and `.cache_info()`) to allow us to extract the cache's `maxsize`. 

Unfortunately, we do **not** have a way to recover the [`typed` parameter](https://docs.python.org/3/library/functools.html#functools.lru_cache) that was added in python 3.3, which causes the decorated function to use separate caches for different input types. This might be enough of a concern that we don't want to merge this PR (or, at least, wouldn't want to enable it without some kind of explicit opt-in from the user). As-is, this PR just silently discards the `typed` param, which is not great.

On PyPy, things are a bit trickier. There, `lru_cache` uses the pure-python implementation from the stdlib, which just returns a closure that closes over the cache state. Since we can already serialize closures, this "works", but it introduces a new issue, which is that PyPy also serializes the cache, which might not be desirable (at least, it seems unfortunate that the behavior would be different between CPython and PyPY). On the other hand, it's not clear how we could prevent this: pickle's dispatching is all type based, and to any external viewer an lru-cached function is just a regular python function on pypy, so there isn't really a way for us to treat lru-cached functions specially unless we want to add a special case to check on all function serializations (e.g. we could branch on `if hasattr(func, 'cache_clear')` or similar). Whether that cost is worth the effort to ensure consistency between CPython and PyPy is an interesting question. I'm seeing several unrelated test failures on `pypy` on master anyway, so maybe we don't care?
