### PR TITLE
Pickling of generic annotations/types in 3.5+

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install optional typing_extensions in Python 3.6
       shell: bash
       run: python -m pip install typing-extensions
-      if: matrix.python_version == "3.6"
+      if: matrix.python_version == '3.6'
     - name: Display Python version
       shell: bash
       run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -61,6 +61,10 @@ jobs:
         python -m pip install -r dev-requirements.txt
         python ci/install_coverage_subprocess_pth.py
         export
+    - name: Install optional typing_extensions in Python 3.6
+      shell: bash
+      run: python -m pip install typing-extensions
+      if: matrix.python_version == "3.6"
     - name: Display Python version
       shell: bash
       run: python -c "import sys; print(sys.version)"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
   instances on Python 3.7+
   ([PR #351](https://github.com/cloudpipe/cloudpickle/pull/351))
 
+- Add support for pickling dynamic classes subclassing `typing.Generic`
+  instances on Python 3.5+
+  ([PR #318](https://github.com/cloudpipe/cloudpickle/pull/318))
+
 1.3.0
 =====
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 **This version requires Python 3.5 or later**
 
+- cloudpickle can now all pickle all constructs from the ``typing`` module
+  and the ``typing_extensions`` library in Python 3.5+
+  ([PR #318](https://github.com/cloudpipe/cloudpickle/pull/318))
+
 - Stop pickling the annotations of a dynamic class for Python < 3.6
   (follow up on #276)
   ([issue #347](https://github.com/cloudpipe/cloudpickle/issues/347))
@@ -14,10 +18,6 @@
 - Add support for pickling dynamic classes subclassing `typing.Generic`
   instances on Python 3.7+
   ([PR #351](https://github.com/cloudpipe/cloudpickle/pull/351))
-
-- Add support for pickling dynamic classes subclassing `typing.Generic`
-  instances on Python 3.5+
-  ([PR #318](https://github.com/cloudpipe/cloudpickle/pull/318))
 
 1.3.0
 =====

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -424,7 +424,7 @@ def _extract_class_dict(cls):
     return clsdict
 
 
-if sys.version_info[:2] < (3, 7):  # pramga: no branch
+if sys.version_info[:2] < (3, 7):  # pragma: no branch
     def _is_parametrized_type_hint(obj):
         # This is very cheap but might generate false positives.
         origin = getattr(obj, '__origin__', None)  # typing Constructs
@@ -974,7 +974,7 @@ class CloudPickler(Pickler):
                     initargs = (obj.__origin__, args)
                 else:
                     initargs = (obj.__origin__, (list(args[:-1]), args[-1]))
-            else:  # pramga: no cover
+            else:  # pragma: no cover
                 raise pickle.PicklingError(
                     "Cloudpickle Error: Unknown type {}".format(type(obj))
                 )

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -67,7 +67,7 @@ from pickle import _getattribute
 from io import BytesIO
 from importlib._bootstrap import _find_spec
 
-try:
+try:  # pragma: no branch
     import typing_extensions as _typing_extensions
     from typing_extensions import Literal, Final
 except ImportError:
@@ -124,7 +124,7 @@ def _whichmodule(obj, name):
     - Errors arising during module introspection are ignored, as those errors
       are considered unwanted side effects.
     """
-    if sys.version_info[:2] < (3, 7) and isinstance(obj, typing.TypeVar):
+    if sys.version_info[:2] < (3, 7) and isinstance(obj, typing.TypeVar):  # pragma: no branch  # noqa
         # Workaround bug in old Python versions: prior to Python 3.7,
         # T.__module__ would always be set to "typing" even when the TypeVar T
         # would be defined in a different module.
@@ -960,9 +960,9 @@ class CloudPickler(Pickler):
             # The distorted type check sematic for typing construct becomes:
             # ``type(obj) is type(TypeHint)``, which means "obj is a
             # parametrized TypeHint"
-            if type(obj) is type(Literal):
+            if type(obj) is type(Literal):  # pragma: no branch
                 initargs = (Literal, obj.__values__)
-            elif type(obj) is type(Final):
+            elif type(obj) is type(Final):  # pragma: no branch
                 initargs = (Final, obj.__type__)
             elif type(obj) is type(ClassVar):
                 initargs = (ClassVar, obj.__type__)

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2075,7 +2075,8 @@ class CloudPickleTest(unittest.TestCase):
 
         assert pickle_depickle(C, protocol=self.protocol) is C
 
-        # Identity is not part of the typing contract.
+        # Identity is not part of the typing contract: only test for
+        # equality instead.
         assert pickle_depickle(C[int], protocol=self.protocol) == C[int]
 
         with subprocess_worker(protocol=self.protocol) as worker:

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2105,9 +2105,11 @@ class CloudPickleTest(unittest.TestCase):
                 MyClass.__annotations__ = {'attribute': type_}
 
                 def check_annotations(obj, expected_type):
-                    assert obj.__annotations__["attribute"] is expected_type
-                    assert obj.method.__annotations__["arg"] is expected_type
-                    assert obj.method.__annotations__["return"] is expected_type
+                    assert obj.__annotations__["attribute"] == expected_type
+                    assert obj.method.__annotations__["arg"] == expected_type
+                    assert (
+                        obj.method.__annotations__["return"] == expected_type
+                    )
                     return "ok"
 
                 obj = MyClass()
@@ -2125,7 +2127,8 @@ class CloudPickleTest(unittest.TestCase):
         ]
 
         for obj in objs:
-            _ = pickle_depickle(obj, protocol=self.protocol)
+            depickled_obj = pickle_depickle(obj, protocol=self.protocol)
+            assert depickled_obj == obj
 
     def test_class_annotations(self):
         class C:

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1787,9 +1787,6 @@ class CloudPickleTest(unittest.TestCase):
 
         self.assertEqual(f2.__doc__, f.__doc__)
 
-    @unittest.skipIf(sys.version_info < (3, 7),
-                     "Pickling type annotations isn't supported for py36 and "
-                     "below.")
     def test_wraps_preserves_function_annotations(self):
         def f(x):
             pass
@@ -1804,79 +1801,7 @@ class CloudPickleTest(unittest.TestCase):
 
         self.assertEqual(f2.__annotations__, f.__annotations__)
 
-    @unittest.skipIf(sys.version_info >= (3, 7),
-                     "pickling annotations is supported starting Python 3.7")
-    def test_function_annotations_silent_dropping(self):
-        # Because of limitations of typing module, cloudpickle does not pickle
-        # the type annotations of a dynamic function or class for Python < 3.7
-
-        class UnpicklableAnnotation:
-            # Mock Annotation metaclass that errors out loudly if we try to
-            # pickle one of its instances
-            def __reduce__(self):
-                raise Exception("not picklable")
-
-        unpickleable_annotation = UnpicklableAnnotation()
-
-        def f(a: unpickleable_annotation):
-            return a
-
-        with pytest.raises(Exception):
-            cloudpickle.dumps(f.__annotations__)
-
-        depickled_f = pickle_depickle(f, protocol=self.protocol)
-        assert depickled_f.__annotations__ == {}
-
-    @unittest.skipIf(sys.version_info >= (3, 7) or sys.version_info < (3, 6),
-                     "pickling annotations is supported starting Python 3.7")
-    def test_class_annotations_silent_dropping(self):
-        # Because of limitations of typing module, cloudpickle does not pickle
-        # the type annotations of a dynamic function or class for Python < 3.7
-
-        # Pickling and unpickling must be done in different processes when
-        # testing dynamic classes (see #313)
-
-        code = '''if 1:
-        import cloudpickle
-        import sys
-
-        class UnpicklableAnnotation:
-            # Mock Annotation metaclass that errors out loudly if we try to
-            # pickle one of its instances
-            def __reduce__(self):
-                raise Exception("not picklable")
-
-        unpickleable_annotation = UnpicklableAnnotation()
-
-        class A:
-            a: unpickleable_annotation
-
-        try:
-            cloudpickle.dumps(A.__annotations__)
-        except Exception:
-            pass
-        else:
-            raise AssertionError
-
-        sys.stdout.buffer.write(cloudpickle.dumps(A, protocol={protocol}))
-        '''
-        cmd = [sys.executable, '-c', code.format(protocol=self.protocol)]
-        proc = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-        proc.wait()
-        out, err = proc.communicate()
-        assert proc.returncode == 0, err
-
-        depickled_a = pickle.loads(out)
-        assert not hasattr(depickled_a, "__annotations__")
-
-    @unittest.skipIf(sys.version_info < (3, 7),
-                     "Pickling type hints isn't supported for py36"
-                     " and below.")
     def test_type_hint(self):
-        # Try to pickle compound typing constructs. This would typically fail
-        # on Python < 3.7 (See #193)
         t = typing.Union[list, int]
         assert pickle_depickle(t) == t
 
@@ -2142,8 +2067,6 @@ class CloudPickleTest(unittest.TestCase):
         from typing import AnyStr
         assert AnyStr is pickle_depickle(AnyStr, protocol=self.protocol)
 
-    @unittest.skipIf(sys.version_info < (3, 7),
-                     "Pickling generics not supported below py37")
     def test_generic_type(self):
         T = typing.TypeVar('T')
 
@@ -2170,22 +2093,13 @@ class CloudPickleTest(unittest.TestCase):
             assert check_generic(C[int], C, int) == "ok"
             assert worker.run(check_generic, C[int], C, int) == "ok"
 
-    @unittest.skipIf(sys.version_info < (3, 7),
-                     "Pickling type hints not supported below py37")
     def test_locally_defined_class_with_type_hints(self):
         with subprocess_worker(protocol=self.protocol) as worker:
             for type_ in _all_types_to_test():
-                # The type annotation syntax causes a SyntaxError on Python 3.5
-                code = textwrap.dedent("""\
                 class MyClass:
-                    attribute: type_
-
                     def method(self, arg: type_) -> type_:
                         return arg
-                """)
-                ns = {"type_": type_}
-                exec(code, ns)
-                MyClass = ns["MyClass"]
+                MyClass.__annotations__ = {'attribute': type_}
 
                 def check_annotations(obj, expected_type):
                     assert obj.__annotations__["attribute"] is expected_type
@@ -2196,6 +2110,34 @@ class CloudPickleTest(unittest.TestCase):
                 obj = MyClass()
                 assert check_annotations(obj, type_) == "ok"
                 assert worker.run(check_annotations, obj, type_) == "ok"
+
+    def test_generic_extensions(self):
+        typing_extensions = pytest.importorskip('typing_extensions')
+
+        objs = [
+            typing_extensions.Literal,
+            typing_extensions.Final,
+            typing_extensions.Literal['a'],
+            typing_extensions.Final[int],
+        ]
+
+        for obj in objs:
+            _ = pickle_depickle(obj, protocol=self.protocol)
+
+    def test_class_annotations(self):
+        class C:
+            pass
+        C.__annotations__ = {'a': int}
+
+        C1 = pickle_depickle(C, protocol=self.protocol)
+        assert C1.__annotations__ == C.__annotations__
+
+    def test_function_annotations(self):
+        def f(a: int) -> str:
+            pass
+
+        f1 = pickle_depickle(f, protocol=self.protocol)
+        assert f1.__annotations__ == f.__annotations__
 
 
 class Protocol2CloudPickleTest(CloudPickleTest):

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2074,7 +2074,9 @@ class CloudPickleTest(unittest.TestCase):
             pass
 
         assert pickle_depickle(C, protocol=self.protocol) is C
-        assert pickle_depickle(C[int], protocol=self.protocol) is C[int]
+
+        # Identity is not part of the typing contract.
+        assert pickle_depickle(C[int], protocol=self.protocol) == C[int]
 
         with subprocess_worker(protocol=self.protocol) as worker:
 


### PR DESCRIPTION
This PR adds support for pickling annotations on 3.5+, and fixes some problems with generic annotations on 3.7+.

## TODO

- [x] Backport for 3.5
- [x] Test that fails with `TypeError: type() doesn't support MRO entry resolution; use types.new_class()` if not using `types.new_class` for reconstructing classes
- [x] Remove `typing_extensions` dependency
- [x] Prefix privates with `_`
- [x] Add test for `pickle_depickle`'ing annotated functions/classes

## Details

The `types.new_class` change (in `_make_skeleton_class`) is because of a `TypeError: type() doesn't support MRO entry resolution; use types.new_class()` error on 3.7+, similar to [this issue](https://bugs.python.org/issue33188). Also see https://github.com/python/cpython/pull/6319.

I'm not sure if there are any downsides to `TypeVar`s being `__reduce__`'d now. Previously, they were only supported as globals (so always imported, I think).

The functions `try_decompose_generic` and `get_bases` are brittle the way they are written, because they check for attributes. There might be a better way.

## Tests
Passing, and added some new ones.