### PR TITLE
FIX dont pickle __builtins__ of dynamic modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,6 @@ before_script:
   - $PYTHON_EXE -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   - $PYTHON_EXE ci/install_coverage_subprocess_pth.py
 script:
-  - $PYTHON_EXE -c "import sys; print(sys.version)"
   - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' $PYTHON_EXE -m pytest -r s
   - |
     if [[ $PROJECT != "" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,6 +128,7 @@ before_script:
   - $PYTHON_EXE -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   - $PYTHON_EXE ci/install_coverage_subprocess_pth.py
 script:
+  - $PYTHON_EXE -c "import sys; print(sys.version)"
   - COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" PYTHONPATH='.:tests' $PYTHON_EXE -m pytest -r s
   - |
     if [[ $PROJECT != "" ]]; then

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
-1.2.3
+1.3.0
 =====
+
 - Fix a bug affecting dynamic modules occuring with modified builtins
   ([issue #316](https://github.com/cloudpipe/cloudpickle/issues/316))
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 1.2.3
 =====
+- Fix a bug affecting dynamic modules occuring with modified builtins
+  ([issue #316](https://github.com/cloudpipe/cloudpickle/issues/316))
 
 - Fix a bug affecting cloudpickle when non-modules objects are added into
   sys.modules

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 1.3.0
 =====
 
+- Fix a bug affecting cloudpickle when non-modules objects are added into
+  sys.modules
+  ([PR #326](https://github.com/cloudpipe/cloudpickle/pull/326)).
+
 - Fix a bug affecting dynamic modules occuring with modified builtins
   ([issue #316](https://github.com/cloudpipe/cloudpickle/issues/316))
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,6 @@
 1.3.0
 =====
 
-- Fix a bug affecting cloudpickle when non-modules objects are added into
-  sys.modules
-  ([PR #326](https://github.com/cloudpipe/cloudpickle/pull/326)).
-
 - Fix a bug affecting dynamic modules occuring with modified builtins
   ([issue #316](https://github.com/cloudpipe/cloudpickle/issues/316))
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 - Fix a bug affecting dynamic modules occuring with modified builtins
   ([issue #316](https://github.com/cloudpipe/cloudpickle/issues/316))
 
+1.2.3
+=====
+
 - Fix a bug affecting cloudpickle when non-modules objects are added into
   sys.modules
   ([PR #326](https://github.com/cloudpipe/cloudpickle/pull/326)).

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -42,7 +42,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 from __future__ import print_function
 
-import builtins
 import dis
 from functools import partial
 import io
@@ -91,6 +90,7 @@ if sys.version_info[0] < 3:  # pragma: no branch
         from cStringIO import StringIO
     except ImportError:
         from StringIO import StringIO
+    import __builtin__ as builtins
     string_types = (basestring,)  # noqa
     PY3 = False
     PY2 = True
@@ -102,6 +102,7 @@ else:
     PY3 = True
     PY2 = False
     from importlib._bootstrap import _find_spec
+    import builtins
 
 _extract_code_globals_cache = weakref.WeakKeyDictionary()
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -42,6 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 from __future__ import print_function
 
+import builtins
 import dis
 from functools import partial
 import io
@@ -510,6 +511,7 @@ class CloudPickler(Pickler):
         Save a module as an import
         """
         if _is_dynamic(obj):
+            obj.__dict__.pop('__builtins__', None)
             self.save_reduce(dynamic_subimport, (obj.__name__, vars(obj)),
                              obj=obj)
         else:
@@ -1149,6 +1151,7 @@ def subimport(name):
 def dynamic_subimport(name, vars):
     mod = types.ModuleType(name)
     mod.__dict__.update(vars)
+    mod.__dict__['__builtins__'] = builtins.__dict__
     return mod
 
 

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -274,6 +274,7 @@ def _memoryview_reduce(obj):
 
 def _module_reduce(obj):
     if _is_dynamic(obj):
+        obj.__dict__.pop('__builtins__', None)
         return dynamic_subimport, (obj.__name__, vars(obj))
     else:
         return subimport, (obj.__name__,)

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -528,7 +528,7 @@ class CloudPickleTest(unittest.TestCase):
         finally:
             os.unlink(pickled_func_path)
 
-    def test_module_with_unpicklable_builtin(self):
+    def test_dynamic_module_with_unpicklable_builtin(self):
         # Reproducer of https://github.com/cloudpipe/cloudpickle/issues/316
         # Some modules such as scipy inject some unpicklable objects into the
         # __builtins__ module, which appears in every module's __dict__ under

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -534,7 +534,7 @@ class CloudPickleTest(unittest.TestCase):
         # __builtins__ module, which appears in every module's __dict__ under
         # the '__builtins__' key. In such cases, cloudpickle used to fail
         # when pickling dynamic modules.
-        class UnpickleableObject:
+        class UnpickleableObject(object):
             def __reduce__(self):
                 raise ValueError('Unpicklable object')
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -553,6 +553,8 @@ class CloudPickleTest(unittest.TestCase):
         mod.__dict__['__builtins__']['unpickleable_object'] = unpicklable_obj
 
         depickled_mod = pickle_depickle(mod, protocol=self.protocol)
+        assert '__builtins__' in depickled_mod.__dict__
+        assert "abs" in depickled_mod.__builtins__
         assert depickled_mod.f(-1) == 1
 
     def test_load_dynamic_module_in_grandchild_process(self):


### PR DESCRIPTION
Closes #316 
`save_module` saves all entries of a dynamic module `__dict__`, including the  `__builtins__`. If they get populated with unpickleable object, `save_module` will fail. This PR proposes to discard `__builtins__` at pickling time and re-create a `__builtins__` entry at unpickling time using the `builtins` module. They should correspond according to the [CPython docs](https://docs.python.org/3/library/builtins.html), although it is not guaranteed.

@ogrisel 