### PR TITLE
FIX check the type of the entries in sys.modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,12 @@ matrix:
       python: "pypy3"
     - os: linux
       env: PYTHON_NIGHTLY=1
+      if: commit_message =~ /\[ci python-nightly\]/
       python: 3.7
     - os: linux
       python: 3.7
+    - os: linux
+      python: "3.8-dev"
     - os: linux
       python: 3.6
     - os: linux
@@ -34,9 +37,9 @@ matrix:
       python: 3.7
       sudo: required
       env: PROJECT=distributed
-           TEST_REQUIREMENTS="pytest pytest-timeout numpy pandas mock bokeh"
+           TEST_REQUIREMENTS="pytest pytest-timeout numpy pandas mock bokeh fsspec>=0.3.3"
            PROJECT_URL=https://github.com/dask/distributed.git
-           PYTEST_ADDOPTS="--timeout-method=thread --timeout=300 -m \"not avoid_travis\" -k \"not test_dask_scheduler and not test_defaults and not test_service_hosts and not test_logging_file_config and not test_hostport and not test_workdir_simple and not test_two_workspaces_in_same_directory and not test_recompute_released_results and not test_connection_args and not test_listen_args\""
+           PYTEST_ADDOPTS="--timeout-method=thread --timeout=300 -m \"not avoid_travis\" -k \"not test_dask_scheduler and not test_workspace_concurrency and not test_defaults and not test_service_hosts and not test_logging_file_config and not test_hostport and not test_workdir_simple and not test_two_workspaces_in_same_directory and not test_recompute_released_results and not test_connection_args and not test_listen_args\""
       if: commit_message =~ /(\[ci downstream\]|\[ci distributed\])/
     - os: linux
       env: PROJECT=loky TEST_REQUIREMENTS="pytest psutil"
@@ -91,11 +94,18 @@ install:
   - $PYTHON_EXE -m pip install .
   - $PYTHON_EXE -m pip install --upgrade -r dev-requirements.txt
   - $PYTHON_EXE -m pip install tornado
-  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
-        if [[ "$PYTHON_NIGHTLY" == "1" ]]; then
-          $PYTHON_EXE -m pip install git+https://github.com/cython/cython git+https://github.com/numpy/numpy;
+  - |
+    if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then
+        if [[ "$TRAVIS_PYTHON_VERSION" == "3.8-dev" ]] || [[ "$PYTHON_NIGHTLY" == "1" ]]; then
+            # installing scipy from pip builds it from source; thus we need to
+            # install blas implementation on our system. This ought to be
+            # deleted once scipy has proper binary wheels for 3.8
+            if [[ $TRAVIS_OS_NAME == "linux" ]]; then
+                sudo apt-get install libopenblas-dev
+                $PYTHON_EXE -m pip install numpy scipy
+            fi
         else
-          $PYTHON_EXE -m pip install numpy scipy;
+            $PYTHON_EXE -m pip install numpy scipy
         fi
     fi
   - if [[ $PROJECT != "" ]]; then

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 1.2.3
 =====
 
+- Fix a bug affecting cloudpickle when non-modules objects are added into
+  sys.modules
+  ([PR #326](https://github.com/cloudpipe/cloudpickle/pull/326)).
+
 - Fix a bug when a thread imports a module while cloudpickle iterates
   over the module list
   ([PR #322](https://github.com/cloudpipe/cloudpickle/pull/322)).

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -154,7 +154,13 @@ def _whichmodule(obj, name):
     # Protect the iteration by using a list copy of sys.modules against dynamic
     # modules that trigger imports of other modules upon calls to getattr.
     for module_name, module in list(sys.modules.items()):
-        if module_name == '__main__' or module is None:
+        # Some modules such as coverage can inject non-module objects inside
+        # sys.modules
+        if (
+                module_name == '__main__' or
+                module is None or
+                not isinstance(module, types.ModuleType)
+        ):
             continue
         try:
             if _getattribute(module, name)[0] is obj:

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -42,7 +42,7 @@ except ImportError:
 import cloudpickle
 from cloudpickle.cloudpickle import _is_dynamic
 from cloudpickle.cloudpickle import _make_empty_cell, cell_set
-from cloudpickle.cloudpickle import _extract_class_dict
+from cloudpickle.cloudpickle import _extract_class_dict, _whichmodule
 
 from .testutils import subprocess_pickle_echo
 from .testutils import assert_run_python_script

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1067,7 +1067,7 @@ class CloudPickleTest(unittest.TestCase):
                 if name == 'func':
                     return func
                 else:
-                    raise ValueError
+                    raise AttributeError
 
         non_module_object = NonModuleObject()
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1055,7 +1055,7 @@ class CloudPickleTest(unittest.TestCase):
         def func(x):
             return x ** 2
 
-        func.__module__ = "NonModuleObject"
+        func.__module__ = None
 
         class NonModuleObject(object):
             def __getattr__(self, name):

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1052,13 +1052,13 @@ class CloudPickleTest(unittest.TestCase):
         # https://github.com/cloudpipe/cloudpickle/pull/326: cloudpickle should
         # not try to instrospect non-modules object when trying to discover the
         # module of a function/class. This happenened because codecov injects
-        # tuples (and not modules) into sys.modules, but type-checks where not
+        # tuples (and not modules) into sys.modules, but type-checks were not
         # carried out on the entries of sys.modules, causing cloupdickle to
         # then error in unexpected ways
         def func(x):
             return x ** 2
 
-        # trigger a loop during the execution of whichmodule(func) by
+        # Trigger a loop during the execution of whichmodule(func) by
         # explicitly setting the function's module to None
         func.__module__ = None
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1097,7 +1097,11 @@ class CloudPickleTest(unittest.TestCase):
         finally:
             sys.modules.pop('NonModuleObject')
 
-    def test_faulty_module(self):
+    def test_unrelated_faulty_module(self):
+        # Check that pickling a dynamically defined function or class does not
+        # fail when introspecting the currently loaded modules in sys.modules
+        # as long as those faulty modules are unrelated to the class or
+        # function we are currently pickling.
         for base_class in (object, types.ModuleType):
             for module_name in ['_missing_module', None]:
                 class FaultyModule(base_class):

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1051,10 +1051,15 @@ class CloudPickleTest(unittest.TestCase):
     def test_non_module_object_passing_whichmodule_test(self):
         # https://github.com/cloudpipe/cloudpickle/pull/326: cloudpickle should
         # not try to instrospect non-modules object when trying to discover the
-        # module of a function/class
+        # module of a function/class. This happenened because codecov injects
+        # tuples (and not modules) into sys.modules, but type-checks where not
+        # carried out on the entries of sys.modules, causing cloupdickle to
+        # then error in unexpected ways
         def func(x):
             return x ** 2
 
+        # trigger a loop during the execution of whichmodule(func) by
+        # explicitly setting the function's module to None
         func.__module__ = None
 
         class NonModuleObject(object):

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1076,7 +1076,7 @@ class CloudPickleTest(unittest.TestCase):
 
         # Any manipulation of non_module_object relying on attribute access
         # will raise an Exception
-        with pytest.raises(ValueError):
+        with pytest.raises(AttributeError):
             _is_dynamic(non_module_object)
 
         try:


### PR DESCRIPTION
Some modules such as `coverage` can inject some non-module objects inside `sys.modules`, creating unpredictable bugs while trying to infer the module of a function. This currently affects one test inside the `PyPy` entry of `cloudpickle` CI. This PR adds an additional type check when manipulating entries of `sys.modules` during `_whichmodule`.