### PR TITLE
Increase the memory threshold used in memory-leak tests

### DIFF
--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1534,11 +1534,14 @@ class CloudPickleTest(unittest.TestCase):
             # the end of each remote function call.
             growth = w.memsize() - reference_size
 
-            # Note that an "empty" Python interpreter on MacOS uses a
-            # significantly bigger amount of memory than on Linux systems
-            # (~10MB vs ~1MB), so the upper-bound on the memory use growth used
-            # below is only tight on Mac, and could be largely reduced on
-            # Linux.
+            # For some reason, the memory growth after processing 100MB of
+            # data is ~10MB on MacOS, and ~1MB on Linux, so the upper bound on
+            # memory growth we use is only tight for MacOS. However,
+            # - 10MB is still 10x lower than the expected memory growth in case
+            # of a leak (which would be the total size of the processed data,
+            # 100MB)
+            # - the memory usage growth does not increase if using 10000
+            # iterations instead of 100 as used now (100x more data)
             assert growth < 1.5e7, growth
 
         """.format(protocol=self.protocol)

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1533,7 +1533,13 @@ class CloudPickleTest(unittest.TestCase):
             # grown by more than a few MB as closures are garbage collected at
             # the end of each remote function call.
             growth = w.memsize() - reference_size
-            assert growth < 1e7, growth
+
+            # Note that an "empty" Python interpreter on MacOS uses a
+            # significantly bigger amount of memory than on Linux systems
+            # (~10MB vs ~1MB), so the upper-bound on the memory use growth used
+            # below is only tight on Mac, and could be largely reduced on
+            # Linux.
+            assert growth < 1.5e7, growth
 
         """.format(protocol=self.protocol)
         assert_run_python_script(code)


### PR DESCRIPTION
closes #272 

As a `Python` interpreter uses ~10MB of memory on MacOS, `test_interactive_remote_function_calls_no_memory_leak` fails on this system. In the perspective of adding a `cloudpickle` CI entry for Mac, I propose to increase the threshold above which this test fails. 

As a side note, we carried out some tests with @ogrisel to make sure this 10MB memory usage remains stable when increasing the load in this test, and it seems to be the case. So this issue is unlikely to be a memory leak caused by us.