### PR TITLE
test properties on a new-style class.

### DIFF
--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1179,7 +1179,7 @@ class CloudPickleTest(unittest.TestCase):
         self.assertEqual(cloned.__qualname__, func.__qualname__)
 
     def test_property(self):
-        class MyObject:
+        class MyObject(object):
             _read_only_value = 1
             _read_write_value = 1
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1179,6 +1179,8 @@ class CloudPickleTest(unittest.TestCase):
         self.assertEqual(cloned.__qualname__, func.__qualname__)
 
     def test_property(self):
+        # Note that the @property decorator only has an effect on new-style
+        # classes.
         class MyObject(object):
             _read_only_value = 1
             _read_write_value = 1


### PR DESCRIPTION
Follow up on #329 
Properties only work on new-style classes, that's why `test_property` is failing on `Python2` tests.
