### PR TITLE
Add a test for #327

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -84,7 +84,6 @@ jobs:
 
   python-nightly-build:
     runs-on: ubuntu-latest
-    if: "contains(github.event.head_commit.message, '[ci python-nightly]')"
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python Nightly

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -84,6 +84,7 @@ jobs:
 
   python-nightly-build:
     runs-on: ubuntu-latest
+    if: "contains(github.event.head_commit.message, '[ci python-nightly]')"
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python Nightly

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -109,7 +109,8 @@ class CloudPickleTest(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
     @pytest.mark.skipif(
-            sys.version_info >= (3, 8, 0) and sys.version_info < (3, 8, 2),
+            platform.python_implementation() != "CPython" or
+            (sys.version_info >= (3, 8, 0) and sys.version_info < (3, 8, 2)),
             reason="Underlying bug fixed upstream starting Python3.8.2")
     def test_reducer_override_reference_cycle(self):
         # Early versions of Python3.8 introduced a reference cycle between a

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -111,15 +111,15 @@ class CloudPickleTest(unittest.TestCase):
     @pytest.mark.skipif(
             platform.python_implementation() != "CPython" or
             (sys.version_info >= (3, 8, 0) and sys.version_info < (3, 8, 2)),
-            reason="Underlying bug fixed upstream starting Python3.8.2")
+            reason="Underlying bug fixed upstream starting Python 3.8.2")
     def test_reducer_override_reference_cycle(self):
-        # Early versions of Python3.8 introduced a reference cycle between a
+        # Early versions of Python 3.8 introduced a reference cycle between a
         # Pickler and it's reducer_override method. Because a Pickler
         # object references every object it has pickled through its memo, this
         # cycle prevented the garbage-collection of those external pickled
         # objects. See #327 as well as https://bugs.python.org/issue39492
-        # This bug was fixed in Python3.8.2, but is still present using
-        # cloudpickle and Python3.8.0/1, hence the skipif directive.
+        # This bug was fixed in Python 3.8.2, but is still present using
+        # cloudpickle and Python 3.8.0/1, hence the skipif directive.
         class MyClass:
             pass
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -108,6 +108,27 @@ class CloudPickleTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 
+    @pytest.mark.skipif(
+            sys.version_info >= (3, 8, 0) and sys.version_info < (3, 8, 2),
+            reason="Underlying bug fixed upstream starting Python3.8.2")
+    def test_reducer_override_reference_cycle(self):
+        # Early versions of Python3.8 introduced a reference cycle between a
+        # Pickler and it's reducer_override method. Because a Pickler
+        # object references every object it has pickled through its memo, this
+        # cycle prevented the garbage-collection of those external pickled
+        # objects. See #327 as well as https://bugs.python.org/issue39492
+        # This bug was fixed in Python3.8.2, but is still present using
+        # cloudpickle and Python3.8.0/1, hence the skipif directive.
+        class MyClass:
+            pass
+
+        my_object = MyClass()
+        wr = weakref.ref(my_object)
+
+        cloudpickle.dumps(my_object)
+        del my_object
+        assert wr() is None, "'del'-ed my_object has not been collected"
+
     def test_itemgetter(self):
         d = range(10)
         getter = itemgetter(1)


### PR DESCRIPTION
Closes #327 

The #327 bug was fixed upstream starting `Python3.8.2`. We should test whether this properly fixes the `cloudpickle` reproducer, hence this test.

Note that there this bug will still be present when using `cloudpickle` with `Python3.8.0/1`. This is too hard to fix in `cloudpickle`.