### PR TITLE
Test that downstream builds are triggered when a PR is labeled with 'ci downstream'

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,4 @@
-name: Automated Tests
+name: Automated tests
 
 on:
   push:


### PR DESCRIPTION
test PR to check that the downstream projects tests are well ran when the label 'ci downstream' is set.