### PR TITLE
Drop annotation of dynamic classes when pickling for Python < 3.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 **This version requires Python 3.5 or later**
 
+- Stop pickling the annotations of a dynamic class for Python < 3.6
+  (follow up on #276)
+  ([issue #347](https://github.com/cloudpipe/cloudpickle/issues/347))
+
 1.3.0
 =====
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -581,6 +581,11 @@ class CloudPickler(Pickler):
         if isinstance(__dict__, property):
             type_kwargs['__dict__'] = __dict__
 
+        if sys.version_info < (3, 7):
+            # Although annotations were added in Python 3.4, It is not possible
+            # to properly pickle them until Python 3.7. (See #193)
+            clsdict.pop('__annotations__', None)
+
         save = self.save
         write = self.write
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -22,6 +22,8 @@ import unittest
 import weakref
 import os
 import enum
+import typing
+from functools import wraps
 
 import pytest
 
@@ -1784,11 +1786,9 @@ class CloudPickleTest(unittest.TestCase):
         self.assertEqual(f2.__doc__, f.__doc__)
 
     @unittest.skipIf(sys.version_info < (3, 7),
-                     "This syntax won't work on py2 and pickling annotations "
-                     "isn't supported for py37 and below.")
+                     "Pickling type annotations isn't supported for py36 and "
+                     "below.")
     def test_wraps_preserves_function_annotations(self):
-        from functools import wraps
-
         def f(x):
             pass
 
@@ -1870,12 +1870,11 @@ class CloudPickleTest(unittest.TestCase):
         assert not hasattr(depickled_a, "__annotations__")
 
     @unittest.skipIf(sys.version_info < (3, 7),
-                     """This syntax won't work on py2 and pickling annotations
-                     isn't supported for py37 and below.""")
+                     "Pickling type hints isn't supported for py36"
+                     " and below.")
     def test_type_hint(self):
         # Try to pickle compound typing constructs. This would typically fail
         # on Python < 3.7 (See #193)
-        import typing
         t = typing.Union[list, int]
         assert pickle_depickle(t) == t
 


### PR DESCRIPTION
fixes #347 

cc @ogrisel 