### PR TITLE
Support pickling dynamic classes subclassing `typing.Generic` instances on 3.7+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,8 @@
   and expand the support for pickling `TypeVar` instances (dynamic or non-dynamic)
   to Python 3.5-3.6 ([PR #350](https://github.com/cloudpipe/cloudpickle/pull/350))
 
-- Add support for pickling dynamic generics on 3.7+
+- Add support for pickling dynamic classes subclassing `typing.Generic`
+  instances on Python 3.7+
   ([PR #351](https://github.com/cloudpipe/cloudpickle/pull/351))
 
 1.3.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
   and expand the support for pickling `TypeVar` instances (dynamic or non-dynamic)
   to Python 3.5-3.6 ([PR #350](https://github.com/cloudpipe/cloudpickle/pull/350))
 
+- Add support for pickling dynamic generics on 3.7+
+  ([PR #351](https://github.com/cloudpipe/cloudpickle/pull/351))
+
 1.3.0
 =====
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -446,7 +446,7 @@ class CloudPickler(Pickler):
                 raise
 
     def save_typevar(self, obj):
-        self.save_reduce(*_typevar_reduce(obj))
+        self.save_reduce(*_typevar_reduce(obj), obj=obj)
 
     dispatch[typing.TypeVar] = save_typevar
 

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -28,7 +28,7 @@ from .cloudpickle import (
     _is_dynamic, _extract_code_globals, _BUILTIN_TYPE_NAMES, DEFAULT_PROTOCOL,
     _find_imported_submodules, _get_cell_contents, _is_importable_by_name, _builtin_type,
     Enum, _ensure_tracking,  _make_skeleton_class, _make_skeleton_enum,
-    _extract_class_dict, dynamic_subimport, subimport, _typevar_reduce,
+    _extract_class_dict, dynamic_subimport, subimport, _typevar_reduce, _get_bases,
 )
 
 load, loads = _pickle.load, _pickle.loads
@@ -76,7 +76,7 @@ def _class_getnewargs(obj):
     if isinstance(__dict__, property):
         type_kwargs['__dict__'] = __dict__
 
-    return (type(obj), obj.__name__, obj.__bases__, type_kwargs,
+    return (type(obj), obj.__name__, _get_bases(obj), type_kwargs,
             _ensure_tracking(obj), None)
 
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2212,6 +2212,7 @@ class CloudPickleTest(unittest.TestCase):
                     return "ok"
 
                 obj = MyClass()
+                assert check_annotations(obj, type_) == "ok"
                 assert worker.run(check_annotations, obj, type_) == "ok"
 
     @unittest.skipIf(sys.version_info < (3, 7),

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2194,11 +2194,17 @@ class CloudPickleTest(unittest.TestCase):
 
         with subprocess_worker(protocol=self.protocol) as worker:
             for type_ in all_types:
+                # The type annotation syntax causes a SyntaxError on Python 3.5
+                code = textwrap.dedent("""\
                 class MyClass:
                     attribute: type_
 
                     def method(self, arg: type_) -> type_:
                         return arg
+                """)
+                ns = {"type_": type_}
+                exec(code, ns)
+                MyClass = ns["MyClass"]
 
                 def check_annotations(obj, expected_type):
                     assert obj.__annotations__["attribute"] is expected_type

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2163,6 +2163,7 @@ class CloudPickleTest(unittest.TestCase):
                 def check_annotations(obj, expected_type):
                     assert obj.__annotations__["attribute"] is expected_type
                     assert obj.method.__annotations__["arg"] is expected_type
+                    assert obj.method.__annotations__["return"] is expected_type
                     return "ok"
 
                 obj = MyClass()

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2122,6 +2122,12 @@ class CloudPickleTest(unittest.TestCase):
         for attr in attr_list:
             assert getattr(T, attr) == getattr(depickled_T, attr)
 
+    def test_pickle_dynamic_typevar_memoization(self):
+        T = typing.TypeVar('T')
+        depickled_T1, depickled_T2 = pickle_depickle((T, T),
+                                                     protocol=self.protocol)
+        assert depickled_T1 is depickled_T2
+
     def test_pickle_importable_typevar(self):
         from .mypkg import T
         T1 = pickle_depickle(T, protocol=self.protocol)

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2130,6 +2130,53 @@ class CloudPickleTest(unittest.TestCase):
         from typing import AnyStr
         assert AnyStr is pickle_depickle(AnyStr, protocol=self.protocol)
 
+    @unittest.skipIf(sys.version_info < (3, 7),
+                     "Pickling generics not supported below py37")
+    def test_generic(self):
+        from typing import (
+            Optional, TypeVar, Generic, Tuple, Callable,
+            Dict, Any, ClassVar, NoReturn, Union, List,
+        )
+
+        T = TypeVar('T')
+
+        class C(Generic[T]):
+            pass
+
+        objs = [
+            C, C[int],
+            T, Any, NoReturn, Optional, Generic,
+            Union, ClassVar,
+            Optional[int],
+            Generic[T],
+            Callable[[int], Any],
+            Callable[..., Any],
+            Callable[[], Any],
+            Tuple[int, ...],
+            Tuple[int, C[int]],
+            ClassVar[C[int]],
+            List[int],
+            Dict[int, str],
+        ]
+
+        for obj in objs:
+            _ = pickle_depickle(obj, protocol=self.protocol)
+
+    @unittest.skipIf(sys.version_info < (3, 7),
+                     "Pickling generics not supported below py37")
+    def test_generic_extensions(self):
+        typing_extensions = pytest.importorskip('typing_extensions')
+
+        objs = [
+            typing_extensions.Literal,
+            typing_extensions.Final,
+            typing_extensions.Literal['a'],
+            typing_extensions.Final[int],
+        ]
+
+        for obj in objs:
+            _ = pickle_depickle(obj, protocol=self.protocol)
+
 
 class Protocol2CloudPickleTest(CloudPickleTest):
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2208,7 +2208,6 @@ class CloudPickleTest(unittest.TestCase):
                 obj = MyClass()
                 assert worker.run(check_annotations, obj, type_) == "ok"
 
-
     @unittest.skipIf(sys.version_info < (3, 7),
                      "Pickling generics not supported below py37")
     def test_generic_extensions(self):


### PR DESCRIPTION
~**This PR depends on #350. Only the [last commit](/cloudpipe/cloudpickle/pull/351/commits/7379bfc90f59baa2863da406ec674ed0877fb025) should be reviewed.** When #350 is merged I'll rebase this.~

This involved using `types.new_class`. I checked and the new tests fail without it.