### PR TITLE
Flag PRs as red only if >1% coverage decrease

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        # Allow coverage to drop by up to 1% in a PR before marking it as
+        # failed
+        threshold: '1%'


### PR DESCRIPTION
Many PRs are flagged as red by `codecov` because of insignificant coverage changes. Let's increase a bit the coverage decrease threshold above which `codecov` complains (1%)