### PR TITLE
Add option to treat resources from specific modules as dynamic

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -44,6 +44,7 @@ from __future__ import print_function
 
 import builtins
 import dis
+import inspect
 import opcode
 import platform
 import sys
@@ -124,6 +125,16 @@ def _lookup_class_or_track(class_tracker_id, class_def):
                 class_tracker_id, class_def)
             _DYNAMIC_CLASS_TRACKER_BY_CLASS[class_def] = class_tracker_id
     return class_def
+
+
+def register_dynamic_module(module):
+    module_name = module.__name__ if inspect.ismodule(module) else module
+    _CUSTOM_DYNAMIC_MODULES_BY_NAME.add(module_name)
+
+
+def unregister_dynamic_module(module):
+    module_name = module.__name__ if inspect.ismodule(module) else module
+    _CUSTOM_DYNAMIC_MODULES_BY_NAME.remove(module_name)
 
 
 def _whichmodule(obj, name):

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -234,6 +234,9 @@ def _lookup_module_and_qualname(obj, name=None):
     if module_name == "__main__":
         return None
 
+    if _is_dynamic_module(module_name):
+        return None
+
     # Note: if module_name is in sys.modules, the corresponding module is
     # assumed importable at unpickling time. See #357
     module = sys.modules.get(module_name, None)

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -87,6 +87,9 @@ else:
 # communication speed over compatibility:
 DEFAULT_PROTOCOL = pickle.HIGHEST_PROTOCOL
 
+# Names of modules whose resources should be treated as dynamic.
+_CUSTOM_DYNAMIC_MODULES_BY_NAME = set()
+
 # Track the provenance of reconstructed dynamic classes to make it possible to
 # recontruct instances from the matching singleton class definition when
 # appropriate and preserve the usual "isinstance" semantics of Python objects.

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -137,6 +137,21 @@ def unregister_dynamic_module(module):
     _CUSTOM_DYNAMIC_MODULES_BY_NAME.remove(module_name)
 
 
+def _is_dynamic_module(module, submodules=True):
+    module_name = module.__name__ if inspect.ismodule(module) else module
+    if module_name in _CUSTOM_DYNAMIC_MODULES_BY_NAME:
+        return True
+    if submodules:
+        while True:
+            parent_name = module_name.rsplit(".", 1)[0]
+            if parent_name == module_name:
+                break
+            if parent_name in _CUSTOM_DYNAMIC_MODULES_BY_NAME:
+                return True
+            module_name = parent_name
+    return False
+
+
 def _whichmodule(obj, name):
     """Find the module an object belongs to.
 


### PR DESCRIPTION
Cloudpickle generally considers objects that have a module (i.e., the `__module__` attribute) that is in `sys.modules` to be importable at unpickling time, and only stores a reference to the object instead of fully pickling the underlying code/data. This behaviour is inconvenient in specific cases. This PR adds an option for registering specific modules as "dynamic", so that cloudpickle will fully pickle objects belonging to module instead of just a reference.

## Problem to solve

### Dask.distributed

In [Dask.distributed](https://distributed.dask.org/en/latest/), code is pickled and sent from clients to workers for processing. For example, you might apply a function to every row in a dataframe like so.

```python
df.apply(lambda x: x.sum(), axis=1)
```

The lambda function will get pickled and sent to workers. This is fine for simple, self contained lambdas. But, if the Dask code is organized in a module, and the apply function is passed a function in the module, then the module has to be installed on Dask workers because cloudpickle will only send a reference to the function.

```python
def sum_everything(row):
    return sum(row)

df.apply(sum_everything, axis=1)
```

This is highly inconvenient as `sum_everything` in this example is just a part of the Dask graph definition, and not a shared piece of code meant to be distributed and installed on the Dask workers.

### Dagster

Dagster pipelines can be defined in Python modules and run on remote clusters. Similar to the Dask use case, if a pipeline solid makes a reference to a function in its module instead of being written all inline, then that function will only get pickled as a reference. Again, this makes it necessary to distribute a module that's not meant to be distributed, just to satisfy the pickling process.

### Interactive Development

Pickling code from modules is also convenient during development, where it can be cumbersome or time-consuming to build and install modules repeatedly in remote environments.

## Solution

This PR adds a `register_dynamic_module(module)` function that takes in a module or name of a module to treat as dynamic. The module's named is stored in a set named `_CUSTOM_DYNAMIC_MODULES_BY_NAME`.

For the Dask example above, let's say the code was in a module named `some_module.info`. Before computing the Dask graph, the module can be registered as dynamic with the following.

```python
import cloudpickle
from foo import bar

cloudpickle.register_dynamic_module(bar)        # Method 1: Use module object
cloudpickle.register_dynamic_module("foo.bar")  # Method 2: Specify module name
cloudpickle.register_dynamic_module("foo")      # Alternative: Pass in parent module or name
```

In `_lookup_module_and_qualname(obj, name=None)`, a new condition is added after the check for `module_name is None` and `module_name == "__main__"` to see if `_is_dynamic_module(module_name)` returns True. If so, then `None` is returned, and the `obj` is fully pickled just like the `None` and `__main__` cases.

The `_is_dynamic_module(module, submodules=True)` function will return true if the `module` argument is in the `_CUSTOM_DYNAMIC_MODULES_BY_NAME` set. If `submodules` is true (the default), then the function will also return true if it is a submodule of a registered dynamic module.

Given the submodule handling, the entire `foo` could be registered as dynamic, which would cover `foo.bar` and any other submodules.

## Testing

I'm not sure how best to write test case(s) for this. For local spot testing, I added a submodule under cloudpickle named `test`, and verified things like so.

```
root@fbba985331f1:/project# python
Python 3.8.3 (default, Jun  9 2020, 17:39:39) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import cloudpickle
>>> from cloudpickle import test
>>> cloudpickle.dumps(test.demo)
b'\x80\x05\x95\x1d\x00\x00\x00\x00\x00\x00\x00\x8c\x10cloudpickle.test\x94\x8c\x04demo\x94\x93\x94.'
>>> cloudpickle.register_dynamic_module(test)
>>> cloudpickle.dumps(test.demo)
b'\x80\x05\x95"\x02\x00\x00\x00\x00\x00\x00\x8c\x17cloudpickle.cloudpickle\x94\x8c\r_builtin_type\x94\x93\x94\x8c\nLambdaType\x94\x85\x94R\x94(h\x02\x8c\x08CodeType\x94\x85\x94R\x94(K\x00K\x00K\x00K\x00K\x01KCC\x04d\x01S\x00\x94N\x8c\x01a\x94\x86\x94))\x8c%/project/cloudpickle/test/__init__.py\x94\x8c\x04demo\x94K\x01C\x02\x00\x01\x94))t\x94R\x94}\x94(\x8c\x0b__package__\x94\x8c\x10cloudpickle.test\x94\x8c\x08__name__\x94h\x13\x8c\x08__path__\x94]\x94\x8c\x19/project/cloudpickle/test\x94a\x8c\x08__file__\x94\x8c%/project/cloudpickle/test/__init__.py\x94uNNNt\x94R\x94\x8c\x1ccloudpickle.cloudpickle_fast\x94\x8c\x12_function_setstate\x94\x93\x94h\x1b}\x94}\x94(h\x14h\r\x8c\x0c__qualname__\x94h\r\x8c\x0f__annotations__\x94}\x94\x8c\x0e__kwdefaults__\x94N\x8c\x0c__defaults__\x94N\x8c\n__module__\x94h\x13\x8c\x07__doc__\x94N\x8c\x0b__closure__\x94N\x8c\x17_cloudpickle_submodules\x94]\x94\x8c\x0b__globals__\x94}\x94u\x86\x94\x86R0.'
```

## Other

I've been using a variation of this, written as a runtime patch on cloudpickle, for developing Dask code. It's worked well for me!

Closes #206 