### PR TITLE
Compatibility: expose cloudpickle.CloudPickler also as cloudpickle.Pickler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 1.5.1 (in development)
 ======================
 
+- Provide `cloudpickle.CloudPickler` as `cloudpickle.Pickler`.
+  ([issue #366](https://github.com/cloudpipe/cloudpickle/issues/366))
+
 
 1.5.0
 =====

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,11 @@
 1.5.1 (in development)
 ======================
 
-- Provide `cloudpickle.CloudPickler` as `cloudpickle.Pickler`.
+- `cloudpickle`'s pickle.Pickler subclass (currently defined as
+  `cloudpickle.cloudpickle_fast.CloudPickler`) can and should now be accessed
+  as `cloudpickle.Pickler`. This is the only officially supported way of
+  accessing it. 
+  ([issue #366](https://github.com/cloudpipe/cloudpickle/issues/366))
   ([issue #366](https://github.com/cloudpipe/cloudpickle/issues/366))
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,6 @@
   as `cloudpickle.Pickler`. This is the only officially supported way of
   accessing it. 
   ([issue #366](https://github.com/cloudpipe/cloudpickle/issues/366))
-  ([issue #366](https://github.com/cloudpipe/cloudpickle/issues/366))
 
 
 1.5.0

--- a/cloudpickle/__init__.py
+++ b/cloudpickle/__init__.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 from cloudpickle.cloudpickle import *  # noqa
 from cloudpickle.cloudpickle_fast import CloudPickler, dumps, dump  # noqa
 
+# Conform to the convention used by python serialization libraries, which
+# expose their Pickler subclass at top-level under the  "Pickler" name.
 Pickler = CloudPickler
 
 __version__ = '1.5.1dev0'

--- a/cloudpickle/__init__.py
+++ b/cloudpickle/__init__.py
@@ -4,4 +4,6 @@ from __future__ import absolute_import
 from cloudpickle.cloudpickle import *  # noqa
 from cloudpickle.cloudpickle_fast import CloudPickler, dumps, dump  # noqa
 
+Pickler = CloudPickler
+
 __version__ = '1.5.1dev0'

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2343,7 +2343,8 @@ def _all_types_to_test():
 
 
 def test_module_level_pickler():
-    # GH 366
+    # #366: cloudpickle should expose its pickle.Pickler subclass as
+    # cloudpickle.Pickler
     assert hasattr(cloudpickle, "Pickler")
     assert cloudpickle.Pickler is cloudpickle.CloudPickler
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2342,5 +2342,11 @@ def _all_types_to_test():
     return types_to_test
 
 
+def test_module_level_pickler():
+    # GH 366
+    assert hasattr(cloudpickle, "Pickler")
+    assert cloudpickle.Pickler is cloudpickle.CloudPickler
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Some people/projects expect that a module implementing a Pickler, provides the Pickler class as `<module>.Pickler`, for example pytorch/pytorch#38098.

Since the current version of Cloudpickler doesn't define `cloudpickle.Pickler`, let's define `cloudpickle.Pickler` as `cloudpickle.CloudPickler`.

Fixes #366