### PR TITLE
Check annotations as strings for Python 3.10

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -102,8 +102,8 @@ jobs:
       run: |
         sudo add-apt-repository ppa:deadsnakes/nightly
         sudo apt update
-        sudo apt install python3.9 python3.9-venv python3.9-dev
-        python3.9 -m venv nightly-venv
+        sudo apt install python3.10 python3.10-venv python3.10-dev
+        python3.10 -m venv nightly-venv
         echo "$PWD/nightly-venv/bin" >> $GITHUB_PATH
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 1.7.0 (in development)
 ======================
 
+dev
+===
+
+- Support for pickling type annotations on Python 3.10 as per PEP 563:
+  https://www.python.org/dev/peps/pep-0563/
+  ([PR #400](https://github.com/cloudpipe/cloudpickle/pull/400))
 
 1.6.0
 =====

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2209,21 +2209,31 @@ class CloudPickleTest(unittest.TestCase):
                     assert obj.__annotations__["attribute"] == expected_type
                     if sys.version_info >= (3, 10):
                         # In Python 3.10, type annotations are stored as strings.
-                        # See PEP 563 for more details: https://www.python.org/dev/peps/pep-0563/
-                        assert obj.method.__annotations__["arg"] == expected_type_str
+                        # See PEP 563 for more details:
+                        # https://www.python.org/dev/peps/pep-0563/
                         assert (
-                            obj.method.__annotations__["return"] == expected_type_str
+                            obj.method.__annotations__["arg"]
+                                == expected_type_str
+                        )
+                        assert (
+                            obj.method.__annotations__["return"]
+                                == expected_type_str
                         )
                     else:
-                        assert obj.method.__annotations__["arg"] == expected_type
                         assert (
-                            obj.method.__annotations__["return"] == expected_type
+                            obj.method.__annotations__["arg"] == expected_type
+                        )
+                        assert (
+                            obj.method.__annotations__["return"]
+                                == expected_type
                         )
                     return "ok"
 
                 obj = MyClass()
                 assert check_annotations(obj, type_, "type_") == "ok"
-                assert worker.run(check_annotations, obj, type_, "type_") == "ok"
+                assert (
+                    worker.run(check_annotations, obj, type_, "type_") == "ok"
+                )
 
     def test_generic_extensions_literal(self):
         typing_extensions = pytest.importorskip('typing_extensions')

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2205,17 +2205,25 @@ class CloudPickleTest(unittest.TestCase):
                         return arg
                 MyClass.__annotations__ = {'attribute': type_}
 
-                def check_annotations(obj, expected_type):
+                def check_annotations(obj, expected_type, expected_type_str):
                     assert obj.__annotations__["attribute"] == expected_type
-                    assert obj.method.__annotations__["arg"] == expected_type
-                    assert (
-                        obj.method.__annotations__["return"] == expected_type
-                    )
+                    if sys.version_info >= (3, 10):
+                        # In Python 3.10, type annotations are stored as strings.
+                        # See PEP 563 for more details: https://www.python.org/dev/peps/pep-0563/
+                        assert obj.method.__annotations__["arg"] == expected_type_str
+                        assert (
+                            obj.method.__annotations__["return"] == expected_type_str
+                        )
+                    else:
+                        assert obj.method.__annotations__["arg"] == expected_type
+                        assert (
+                            obj.method.__annotations__["return"] == expected_type
+                        )
                     return "ok"
 
                 obj = MyClass()
-                assert check_annotations(obj, type_) == "ok"
-                assert worker.run(check_annotations, obj, type_) == "ok"
+                assert check_annotations(obj, type_, "type_") == "ok"
+                assert worker.run(check_annotations, obj, type_, "type_") == "ok"
 
     def test_generic_extensions_literal(self):
         typing_extensions = pytest.importorskip('typing_extensions')

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2213,11 +2213,11 @@ class CloudPickleTest(unittest.TestCase):
                         # https://www.python.org/dev/peps/pep-0563/
                         assert (
                             obj.method.__annotations__["arg"]
-                                == expected_type_str
+                            == expected_type_str
                         )
                         assert (
                             obj.method.__annotations__["return"]
-                                == expected_type_str
+                            == expected_type_str
                         )
                     else:
                         assert (
@@ -2225,7 +2225,7 @@ class CloudPickleTest(unittest.TestCase):
                         )
                         assert (
                             obj.method.__annotations__["return"]
-                                == expected_type
+                            == expected_type
                         )
                     return "ok"
 


### PR DESCRIPTION
Hello.

We have already started testing RPM packages in Fedora with Python 3.10a2 and cloudpickle seems to be compatible. The only problem we have so far is in tests, where the new implementation of type annotations is causing an issue.

The problem is caused by the implementation of PEP 563 — type annotations are now stored as strings: https://www.python.org/dev/peps/pep-0563/

This is a simple fix but works. What do you think?