### PR TITLE
Support persistent function.__globals__

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -92,6 +92,8 @@ jobs:
 
   python-nightly:
     runs-on: ubuntu-18.04
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
     - uses: actions/checkout@v1
     - name: Install Python from ppa:deadsnakes/nightly


### PR DESCRIPTION
Support `Pickler#persistent_id` and `Unpickler#persistent_load` for `__globals__` of functions:

```python
__globals__ = {"a": "foo"}

class Pickler(cloudpickle.CloudPickler):
    @staticmethod
    def persistent_id(obj):
        if id(obj) == id(__globals__):
            return "__globals__"

class Unpickler(pickle.Unpickler):
    @staticmethod
    def persistent_load(pid):
        return {"__globals__": __globals__}[pid]

get = eval('lambda: a', __globals__)
file = io.BytesIO()
Pickler(file).dump(get)
dumped = file.getvalue()
self.assertNotIn(b'foo', dumped)
get = Unpickler(io.BytesIO(dumped)).load()
self.assertEqual(id(__globals__), id(get.__globals__))
self.assertEqual('foo', get())
__globals__['a'] = 'bar'
self.assertEqual('bar', get())
```
