### PR TITLE
correct identification of stdlib TypeVar objs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -92,6 +92,8 @@ jobs:
 
   python-nightly:
     runs-on: ubuntu-18.04
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
     - uses: actions/checkout@v1
     - name: Install Python from ppa:deadsnakes/nightly

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -92,8 +92,6 @@ jobs:
 
   python-nightly:
     runs-on: ubuntu-18.04
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
     - uses: actions/checkout@v1
     - name: Install Python from ppa:deadsnakes/nightly

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -137,7 +137,7 @@ def _whichmodule(obj, name):
         # T.__module__ would always be set to "typing" even when the TypeVar T
         # would be defined in a different module.
         if name is not None and getattr(typing, name, None) is obj:
-            # Built-in typeVar defined in typing such as AnyStr
+            # Built-in TypeVar defined in typing such as AnyStr
             return 'typing'
         else:
             # User defined or third-party TypeVar: __module__ attribute is

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -136,11 +136,14 @@ def _whichmodule(obj, name):
         # Workaround bug in old Python versions: prior to Python 3.7,
         # T.__module__ would always be set to "typing" even when the TypeVar T
         # would be defined in a different module.
-        #
-        # For such older Python versions, we ignore the __module__ attribute of
-        # TypeVar instances and instead exhaustively lookup those instances in
-        # all currently imported modules.
-        module_name = None
+        if name is not None and getattr(typing, name, None) is obj:
+            # Built-in typeVar defined in typing such as AnyStr
+            return 'typing'
+        else:
+            # User defined or third-party TypeVar: __module__ attribute is
+            # irrelevant, thus trigger a exhaustive search for obj in all
+            # modules.
+            module_name = None
     else:
         module_name = getattr(obj, '__module__', None)
 


### PR DESCRIPTION
In Python <= 3.7, the module attribute of `TypeVar` constructs is always set to typing and thus irrelevant to the true origin of the construct (stdlib, third-party, user-defined). `cloudpickle` used to cirumvent this issue in `_whichmodule` by exhaustively search for the construct in all imported modules. 

This can generate false positives in the case of stdlib `TypeVar` constructs such as `AnyStr` being used by a imported third-party module. For such `TypeVar` constructs, `_whichmodule` would occasionally flag them as belonging to the said third party module. 

This resulted in a flaky test (`test_lookup_module_and_qualname_stdlib_typevar`) where `typing.AnyStr` was occasionally marked as defined in `_pytest.capture` instead of `typing`.

This PR fixes this bug by looking if the `TypeVar` construct is defined in `typing` before triggering a search in `sys.modules`.
