### PR TITLE
Avoid using ::add-path:: in GitHub Actions workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -100,7 +100,7 @@ jobs:
         sudo apt update
         sudo apt install python3.9 python3.9-venv python3.9-dev
         python3.9 -m venv nightly-venv
-        echo ::add-path::nightly-venv/bin
+        echo "$PWD/nightly-venv/bin" >> $GITHUB_PATH
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"
     - name: Install project and dependencies

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: [3.5, 3.6, 3.7, 3.8, "pypy3"]
+        python_version: [3.5, 3.6, 3.7, 3.8, 3.9, "pypy3"]
         exclude:
           # Do not test all minor versions on all platforms, especially if they
           # are not the oldest/newest supported versions
@@ -37,6 +37,8 @@ jobs:
             python_version: 3.6
           - os: windows-latest
             python_version: 3.7
+          - os: windows-latest
+            python_version: 3.8
             # as of  4/02/2020, psutil won't build under PyPy + Windows
           - os: windows-latest
             python_version: "pypy3"
@@ -44,6 +46,8 @@ jobs:
             python_version: 3.6
           - os: macos-latest
             python_version: 3.7
+          - os: macos-latest
+            python_version: 3.8
           - os: macos-latest
             # numpy triggers: RuntimeError: Polyfit sanity test emitted a
             # warning

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ dist = setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, pypy3
+envlist = py35, py36, py37, py38, py39, pypy3
 
 [testenv]
 deps = -rdev-requirements.txt


### PR DESCRIPTION
See: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/