### PR TITLE
Use string type annotations for Python 3.11 not 3.10

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python_version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python_version }}
     - name: Install project and dependencies

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -96,6 +96,7 @@ jobs:
 
   python-nightly:
     runs-on: ubuntu-18.04
+    # This entry is made optional for now, see https://github.com/cloudpipe/cloudpickle/pull/420
     if: "contains(github.event.pull_request.labels.*.name, 'ci python-nightly')"
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -96,6 +96,7 @@ jobs:
 
   python-nightly:
     runs-on: ubuntu-18.04
+    if: "contains(github.event.pull_request.labels.*.name, 'ci python-nightly')"
     steps:
     - uses: actions/checkout@v1
     - name: Install Python from ppa:deadsnakes/nightly

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: [3.5, 3.6, 3.7, 3.8, 3.9, "pypy3"]
+        python_version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10-dev", "pypy3"]
         exclude:
           # Do not test all minor versions on all platforms, especially if they
           # are not the oldest/newest supported versions

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -102,8 +102,8 @@ jobs:
       run: |
         sudo add-apt-repository ppa:deadsnakes/nightly
         sudo apt update
-        sudo apt install python3.10 python3.10-venv python3.10-dev
-        python3.10 -m venv nightly-venv
+        sudo apt install python3.11 python3.11-venv python3.11-dev
+        python3.11 -m venv nightly-venv
         echo "$PWD/nightly-venv/bin" >> $GITHUB_PATH
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2207,10 +2207,13 @@ class CloudPickleTest(unittest.TestCase):
 
                 def check_annotations(obj, expected_type, expected_type_str):
                     assert obj.__annotations__["attribute"] == expected_type
-                    if sys.version_info >= (3, 10):
-                        # In Python 3.10, type annotations are stored as strings.
+                    if sys.version_info >= (3, 11):
+                        # In Python 3.11, type annotations are stored as strings.
                         # See PEP 563 for more details:
                         # https://www.python.org/dev/peps/pep-0563/
+                        # Originaly scheduled for 3.10, then postponed.
+                        # See this for more details:
+                        # https://mail.python.org/archives/list/python-dev@python.org/thread/CLVXXPQ2T2LQ5MP2Y53VVQFCXYWQJHKZ/
                         assert (
                             obj.method.__annotations__["arg"]
                             == expected_type_str


### PR DESCRIPTION
PEP 563 has been postponed to Python 3.11
https://mail.python.org/archives/list/python-dev@python.org/thread/CLVXXPQ2T2LQ5MP2Y53VVQFCXYWQJHKZ/

Another possibility is to revert this commit: https://github.com/cloudpipe/cloudpickle/commit/8a278a12aa3e469ea727861be2c8627d971a31e3

It's basically up to you to decide whether you want to be ready for Python 3.11 and keep this in the codebase for a year and a half.

And finally, the last possibility might be to use `from __future__ import annotations` to enable the new feature for Python 3.7+.