### PR TITLE
Run Dask's `test_pickle_empty` on CI again

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -167,8 +167,9 @@ jobs:
         export DISABLE_IPV6=1
         # Skipping
         # - test_dont_steal_unknown_function (https://github.com/dask/distributed/issues/3574)
+        # - test_target_duration (https://github.com/dask/distributed/issues/4859)
         # See https://github.com/cloudpipe/cloudpickle/pull/432
-        export PYTEST_ADDOPTS=("-k" "not test_dont_steal_unknown_functions")
+        export PYTEST_ADDOPTS=("-k" "not test_dont_steal_unknown_functions and not test_target_duration")
         source ./.github/scripts/test_downstream_project.sh
 
   joblib-downstream-build:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -166,10 +166,9 @@ jobs:
         # https://github.com/dask/distributed/issues/4514
         export DISABLE_IPV6=1
         # Skipping
-        # - test_pickle_empty until https://github.com/dask/distributed/pull/5303 gets merged,
         # - test_dont_steal_unknown_function (https://github.com/dask/distributed/issues/3574)
         # See https://github.com/cloudpipe/cloudpickle/pull/432
-        export PYTEST_ADDOPTS=("-k" "not test_pickle_empty and not test_dont_steal_unknown_functions")
+        export PYTEST_ADDOPTS=("-k" "not test_dont_steal_unknown_functions")
         source ./.github/scripts/test_downstream_project.sh
 
   joblib-downstream-build:


### PR DESCRIPTION
We needed to skip this in PR ( https://github.com/cloudpipe/cloudpickle/pull/432 ) as it was failing. This has since been fixed upstream ( https://github.com/dask/distributed/pull/5303 ). So readd testing of it.