### PR TITLE
Update `distributed` CI test dependencies

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -141,7 +141,7 @@ jobs:
     if: "contains(github.event.pull_request.labels.*.name, 'ci distributed') || contains(github.event.pull_request.labels.*.name, 'ci downstream')"
     env:
       PROJECT: distributed
-      TEST_REQUIREMENTS: cryptography pytest pytest-timeout numpy pandas mock bokeh fsspec>=0.3.3
+      TEST_REQUIREMENTS: cryptography pytest pytest-asyncio<0.14.0 pytest-timeout pytest-rerunfailures numpy pandas mock bokeh fsspec>=0.3.3
       PROJECT_URL: https://github.com/dask/distributed.git
     strategy:
       matrix:


### PR DESCRIPTION
This PR adds `pytest-asyncio` and `pytest-rerunfailures` as dependencies to `distributed` downstream CI build.

`pytest-asyncio` is needed to run some `distributed` tests, otherwise they will be skipped. For example, looking at the CI builds in https://github.com/cloudpipe/cloudpickle/pull/432, we see this warning about being skipped for lots of tests:

```
...
distributed/tests/test_utils.py: 1 warning
distributed/tests/test_utils_test.py: 4 warnings
distributed/tests/test_worker.py: 7 warnings
  /opt/hostedtoolcache/Python/3.7.11/x64/lib/python3.7/site-packages/_pytest/python.py:172: PytestUnhandledCoroutineWarning: async def functions are not natively supported and have been skipped.
  You need to install a suitable plugin for your async framework, for example:
    - anyio
    - pytest-asyncio
    - pytest-tornasync
    - pytest-trio
    - pytest-twisted
    warnings.warn(PytestUnhandledCoroutineWarning(msg.format(nodeid)))
```

`pytest-rerunfailures` was recently added as a test dependency for `distributed` to automatically re-run some known flaky tests. 

cc @jakirkham 