### PR TITLE
Fix #440: Incorrect pickles for subclasses of generic classes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
   and `abc.abstractstaticmethod`.
   ([PR #450](https://github.com/cloudpipe/cloudpickle/pull/450))
 
+- Support for pickling subclasses of generic classes.
+  ([PR #448](https://github.com/cloudpipe/cloudpickle/pull/448))
+
 2.0.0
 =====
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -910,8 +910,12 @@ def _typevar_reduce(obj):
 
 
 def _get_bases(typ):
-    if hasattr(typ, '__orig_bases__'):
+    if '__orig_bases__' in getattr(typ, '__dict__', {}):
         # For generic types (see PEP 560)
+        # Note that simply checking `hasattr(typ, '__orig_bases__')` is not
+        # correct.  Subclasses of a fully-parameterized generic class does not
+        # have `__orig_bases__` defined, but `hasattr(typ, '__orig_bases__')`
+        # will return True because it's defined in the base class.
         bases_attr = '__orig_bases__'
     else:
         # For regular class objects

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2335,6 +2335,47 @@ class CloudPickleTest(unittest.TestCase):
             assert check_generic(C[int], C, int, use_args) == "ok"
             assert worker.run(check_generic, C[int], C, int, use_args) == "ok"
 
+    def test_generic_subclass(self):
+        T = typing.TypeVar('T')
+
+        class Base(typing.Generic[T]):
+            pass
+
+        class DerivedAny(Base):
+            pass
+
+        class LeafAny(DerivedAny):
+            pass
+
+        class DerivedInt(Base[int]):
+            pass
+
+        class LeafInt(DerivedInt):
+            pass
+
+        class DerivedT(Base[T]):
+            pass
+
+        class LeafT(DerivedT[T]):
+            pass
+
+        klasses = [
+            Base, DerivedAny, LeafAny, DerivedInt, LeafInt, DerivedT, LeafT
+        ]
+        for klass in klasses:
+            assert pickle_depickle(klass, protocol=self.protocol) is klass
+
+        with subprocess_worker(protocol=self.protocol) as worker:
+
+            def check_mro(klass, expected_mro):
+                assert klass.mro() == expected_mro
+                return "ok"
+
+            for klass in klasses:
+                mro = klass.mro()
+                assert check_mro(klass, mro)
+                assert worker.run(check_mro, klass, mro) == "ok"
+
     def test_locally_defined_class_with_type_hints(self):
         with subprocess_worker(protocol=self.protocol) as worker:
             for type_ in _all_types_to_test():


### PR DESCRIPTION
This PR fixes #440: Incorrect pickles for subclasses of generic classes.

As pointed out in the issue comment, the root of the issue lies in `_get_bases`, which returned incorrect values for subclasses of generic classes. For example, the `GLeafAny` class in the issue was determined to have original bases of `(__main__.Generic[~T],)`, although its actual base is `GDerivedAny`, and since that is not an `_GenericAlias`, `GLeafAny` shouldn't have `__orig_bases__` at all.

However, in `_get_bases`, we were using `hasattr(typ, '__orig_bases__')` to check if the class has `__orig_bases__`, which would go through to its bases classes, in this case, to `GDerivedAny.__orig_bases__`. This is wrong; we should only use `__orig_bases__` if it's defined on the current class. Thus my change.