### PR TITLE
Add support for `abc.abstract*` methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 2.1.0 (in development)
 ======================
 
-
+- Support for pickling `abc.abstractproperty`, `abc.abstractclassmethod`,
+  and `abc.abstractstaticmethod`.
+  ([PR #450](https://github.com/cloudpipe/cloudpickle/pull/450))
 
 2.0.0
 =====

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -534,6 +534,10 @@ class CloudPickler(Pickler):
     _dispatch_table[type(OrderedDict().keys())] = _odict_keys_reduce
     _dispatch_table[type(OrderedDict().values())] = _odict_values_reduce
     _dispatch_table[type(OrderedDict().items())] = _odict_items_reduce
+    _dispatch_table[abc.abstractmethod] = _classmethod_reduce
+    _dispatch_table[abc.abstractclassmethod] = _classmethod_reduce
+    _dispatch_table[abc.abstractstaticmethod] = _classmethod_reduce
+    _dispatch_table[abc.abstractproperty] = _property_reduce
 
 
     dispatch_table = ChainMap(_dispatch_table, copyreg.dispatch_table)

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1184,6 +1184,11 @@ class CloudPickleTest(unittest.TestCase):
             def some_staticmethod():
                 """A staticmethod"""
 
+            @property
+            @abc.abstractmethod
+            def some_property():
+                """A property"""
+
         class ConcreteClass(AbstractClass):
             def some_method(self):
                 return 'it works!'
@@ -1195,6 +1200,10 @@ class CloudPickleTest(unittest.TestCase):
 
             @staticmethod
             def some_staticmethod():
+                return 'it works!'
+
+            @property
+            def some_property(self):
                 return 'it works!'
 
         # This abstract class is locally defined so we can safely register
@@ -1218,6 +1227,9 @@ class CloudPickleTest(unittest.TestCase):
 
         self.assertEqual(depickled_class().some_staticmethod(), 'it works!')
         self.assertEqual(depickled_instance.some_staticmethod(), 'it works!')
+
+        self.assertEqual(depickled_class().some_property, 'it works!')
+        self.assertEqual(depickled_instance.some_property, 'it works!')
         self.assertRaises(TypeError, depickled_base)
 
         class DepickledBaseSubclass(depickled_base):
@@ -1231,6 +1243,10 @@ class CloudPickleTest(unittest.TestCase):
 
             @staticmethod
             def some_staticmethod():
+                return 'it works for realz!'
+
+            @property
+            def some_property():
                 return 'it works for realz!'
 
         self.assertEqual(DepickledBaseSubclass().some_method(),
@@ -1261,7 +1277,7 @@ class CloudPickleTest(unittest.TestCase):
 
             @abc.abstractproperty
             def some_property(self):
-                """A staticmethod"""
+                """A property"""
 
         class ConcreteClass(AbstractClass):
             def some_method(self):


### PR DESCRIPTION
This PR adds support for `abc.abstractproperty`, `abc.abstractclassmethod`, and `abc.abstractstaticmethod`. The changes here are mostly a duplicate of what was proposed in https://github.com/cloudpipe/cloudpickle/pull/369 by @KristianHolsheimer plus a copy of the tests added in https://github.com/cloudpipe/cloudpickle/pull/371, but using the `abc.abstract*` methods. Additionally, this PR extends `test_abc` a bit to include coverage for abstract `@property`s. 

As pointed out in https://github.com/cloudpipe/cloudpickle/issues/367#issuecomment-628643963, the `abc.abstract*` methods added here are now deprecated, but it seems reasonable to add support for them anyways as users will still run into them from time to time (xref https://github.com/cloudpipe/cloudpickle/issues/394) 

Closes https://github.com/cloudpipe/cloudpickle/issues/367