### PR TITLE
support pypy 3.8

### DIFF
--- a/cloudpickle/compat.py
+++ b/cloudpickle/compat.py
@@ -1,7 +1,8 @@
 import sys
+import platform
 
 
-if sys.version_info < (3, 8):
+if sys.version_info < (3, 8) or platform.python_implementation() == "PyPy":
     try:
         import pickle5 as pickle  # noqa: F401
         from pickle5 import Pickler  # noqa: F401


### PR DESCRIPTION
pypy 3.8 is released for download.

pypy does not supply _pickle

pypy 3.8 should continue to take the pure python version of pickle used in pypy 3.7.

Check this explicitly.