### PR TITLE
Fix import of pickle module on PYPY 3.8 (#455)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: [3.6, 3.7, 3.8, 3.9, "3.10-dev", "pypy3"]
+        python_version: [3.6, 3.7, 3.8, 3.9, "3.10-dev", "pypy-3.8"]
         exclude:
           # Do not test all minor versions on all platforms, especially if they
           # are not the oldest/newest supported versions
@@ -41,7 +41,7 @@ jobs:
             python_version: 3.8
             # as of  4/02/2020, psutil won't build under PyPy + Windows
           - os: windows-latest
-            python_version: "pypy3"
+            python_version: "pypy-3.8"
           - os: macos-latest
             python_version: 3.6
           - os: macos-latest
@@ -51,7 +51,7 @@ jobs:
           - os: macos-latest
             # numpy triggers: RuntimeError: Polyfit sanity test emitted a
             # warning
-            python_version: "pypy3"
+            python_version: "pypy-3.8"
 
     runs-on: ${{ matrix.os }}
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
   and `abc.abstractstaticmethod`.
   ([PR #450](https://github.com/cloudpipe/cloudpickle/pull/450))
 
+- Fix import of pickle module on PYPY 3.8.
+  ([issue #455](https://github.com/cloudpipe/cloudpickle/issues/455))
+
 2.0.0
 =====
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -44,7 +44,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import builtins
 import dis
 import opcode
-import platform
 import sys
 import types
 import weakref
@@ -53,7 +52,7 @@ import threading
 import typing
 import warnings
 
-from .compat import pickle
+from .compat import pickle, PYPY
 from collections import OrderedDict
 from typing import ClassVar, Generic, Union, Tuple, Callable
 from pickle import _getattribute
@@ -91,8 +90,6 @@ _PICKLE_BY_VALUE_MODULES = set()
 _DYNAMIC_CLASS_TRACKER_BY_CLASS = weakref.WeakKeyDictionary()
 _DYNAMIC_CLASS_TRACKER_BY_ID = weakref.WeakValueDictionary()
 _DYNAMIC_CLASS_TRACKER_LOCK = threading.Lock()
-
-PYPY = platform.python_implementation() == "PyPy"
 
 builtin_code_type = None
 if PYPY:

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -25,14 +25,14 @@ import typing
 from enum import Enum
 from collections import ChainMap, OrderedDict
 
-from .compat import pickle, Pickler
+from .compat import pickle, Pickler, PYPY
 from .cloudpickle import (
     _extract_code_globals, _BUILTIN_TYPE_NAMES, DEFAULT_PROTOCOL,
     _find_imported_submodules, _get_cell_contents, _should_pickle_by_reference,
     _builtin_type, _get_or_create_tracker_id,  _make_skeleton_class,
     _make_skeleton_enum, _extract_class_dict, dynamic_subimport, subimport,
     _typevar_reduce, _get_bases, _make_cell, _make_empty_cell, CellType,
-    _is_parametrized_type_hint, PYPY, cell_set,
+    _is_parametrized_type_hint, cell_set,
     parametrized_type_hint_getinitargs, _create_parametrized_type_hint,
     builtin_code_type,
     _make_dict_keys, _make_dict_values, _make_dict_items,

--- a/cloudpickle/compat.py
+++ b/cloudpickle/compat.py
@@ -1,7 +1,9 @@
 import sys
+import platform
 
+PYPY = platform.python_implementation() == "PyPy"
 
-if sys.version_info < (3, 8):
+if sys.version_info < (3, 8) or PYPY:
     try:
         import pickle5 as pickle  # noqa: F401
         from pickle5 import Pickler  # noqa: F401


### PR DESCRIPTION
Based on feedback given for #454.
Also update GH actions to use PYPY 3.8