### PR TITLE
compat: Import Pickler from "pickle" instead of "_pickle"

### DIFF
--- a/cloudpickle/compat.py
+++ b/cloudpickle/compat.py
@@ -10,4 +10,4 @@ if sys.version_info < (3, 8):
         from pickle import _Pickler as Pickler  # noqa: F401
 else:
     import pickle  # noqa: F401
-    from _pickle import Pickler  # noqa: F401
+    from pickle import Pickler  # noqa: F401


### PR DESCRIPTION
The latter is an implementation detail (see [0]),
and the docs instruct users to "always import the standard version"[0].
Moreover, "pickle.Pickler" is the same as "_pickle.Pickler",
for all recent CPython releases (tested 3.6->3.9).

[0] https://docs.python.org/3.1/whatsnew/3.0.html#library-changes

Fixes: https://github.com/cloudpipe/cloudpickle/issues/458

Signed-off-by: Jan Vesely <jano.vesely@gmail.com>