### PR TITLE
Improve compatibility with "nogil" Python and 3.11

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 - Support and CI configuration for Python 3.11.
   ([PR #467](https://github.com/cloudpipe/cloudpickle/pull/467))
 
+- Support for the experimental `nogil` variant of CPython
+  ([PR #470](https://github.com/cloudpipe/cloudpickle/pull/470))
+
 2.0.0
 =====
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -764,6 +764,7 @@ def _fill_function(*args):
 
 
 def _make_function(code, globals, name, argdefs, closure):
+    # Setting __builtins__ in globals is needed for nogil CPython.
     globals["__builtins__"] = __builtins__
     return types.FunctionType(code, globals, name, argdefs, closure)
 

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -270,7 +270,7 @@ def _code_reduce(obj):
             obj.co_firstlineno, obj.co_linetable, obj.co_freevars,
             obj.co_cellvars
         )
-    elif hasattr(obj, "co_nmeta"):  # pragma: no branch
+    elif hasattr(obj, "co_nmeta"):  # pragma: no cover
         # "nogil" Python: modified attributes from 3.9
         args = (
             obj.co_argcount, obj.co_posonlyargcount,

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -978,6 +978,10 @@ class CloudPickleTest(unittest.TestCase):
         res = loop.run_sync(functools.partial(g2, 5))
         self.assertEqual(res, 7)
 
+    @pytest.mark.skipif(
+        (3, 11, 0, 'beta') <= sys.version_info < (3, 11, 0, 'beta', 2),
+        reason="https://github.com/python/cpython/issues/92932"
+    )
     def test_extended_arg(self):
         # Functions with more than 65535 global vars prefix some global
         # variable references with the EXTENDED_ARG opcode.

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2245,7 +2245,7 @@ class CloudPickleTest(unittest.TestCase):
 
     def test_recursion_during_pickling(self):
         class A:
-            def __getattr__(self, name):
+            def __getattribute__(self, name):
                 return getattr(self, name)
 
         a = A()


### PR DESCRIPTION
This makes a number of changes to improve compatibility with the
"nogil" Python fork as well as the Python 3.11+.

 - Fix `_code_reduce` for 3.11b0 and nogil Python

 - Use instr.argval in _walk_global_ops. This avoids adding a special
   case for 3.11+ (and is useful for nogil Python). In 3.11+, the argval
   for LOAD_GLOBAL would need to be divided by two to access the correct
   name. The 'argval' field already stores the correct name.

 - Set `__builtins__` before constructing de-pickled functions. (Useful
   for nogil Python)

 - Fix test_recursion_during_pickling in Python 3.11+. Objects now have
   a default `__getstate__` method so `__getattr__` was never called,
   but `__getattribute__` would still be called.