### PR TITLE
Fix NamedTuple issues on Python 3.9

### DIFF
--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -111,8 +111,8 @@ load, loads = pickle.load, pickle.loads
 
 def _class_getnewargs(obj):
     type_kwargs = {}
-    if "__slots__" in obj.__dict__:
-        type_kwargs["__slots__"] = obj.__slots__
+    if "__module__" in obj.__dict__:
+        type_kwargs["__module__"] = obj.__module__
 
     __dict__ = obj.__dict__.get('__dict__', None)
     if isinstance(__dict__, property):

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -1564,6 +1564,24 @@ class CloudPickleTest(unittest.TestCase):
         assert isinstance(depickled_t2, MyTuple)
         assert depickled_t2 == t2
 
+    def test_NamedTuple(self):
+        class MyTuple(typing.NamedTuple):
+            a: int
+            b: int
+            c: int
+        
+        t1 = MyTuple(1, 2, 3)
+        t2 = MyTuple(3, 2, 1)
+
+        depickled_t1, depickled_MyTuple, depickled_t2 = pickle_depickle(
+            [t1, MyTuple, t2], protocol=self.protocol)
+
+        assert isinstance(depickled_t1, MyTuple)
+        assert depickled_t1 == t1
+        assert depickled_MyTuple is MyTuple
+        assert isinstance(depickled_t2, MyTuple)
+        assert depickled_t2 == t2
+
     def test_interactively_defined_function(self):
         # Check that callables defined in the __main__ module of a Python
         # script (or jupyter kernel) can be pickled / unpickled / executed.


### PR DESCRIPTION
This PR fixes issue #460. Two changes were required. First, if `__module__` was present in `obj.__dict__`, we need to pass it along to `type_kwargs`. See error message below.
```
cls = <class 'typing.NamedTupleMeta'>, typename = 'MyTuple', bases = (<class 'typing.NamedTuple'>,), ns = {'__orig_bases__': (<function NamedTuple at 0x7fc0780f9310>,), '__slots__': ()}

    def __new__(cls, typename, bases, ns):
        assert bases[0] is _NamedTuple
        types = ns.get('__annotations__', {})
        default_names = []
        for field_name in types:
            if field_name in ns:
                default_names.append(field_name)
            elif default_names:
                raise TypeError(f"Non-default namedtuple field {field_name} "
                                f"cannot follow default field"
                                f"{'s' if len(default_names) > 1 else ''} "
                                f"{', '.join(default_names)}")
        nm_tpl = _make_nmtuple(typename, types.items(),
                               defaults=[ns[n] for n in default_names],
>                              module=ns['__module__'])
E       KeyError: '__module__'
```

Second, if we pass `__slots__` and `__module__` to `type_kwargs` then we get the following error:
```
cls = <class 'typing.NamedTupleMeta'>, typename = 'MyTuple', bases = (<class 'typing.NamedTuple'>,)
ns = {'__module__': 'tests.cloudpickle_test', '__orig_bases__': (<function NamedTuple at 0x7fa300131310>,), '__slots__': ()}

    def __new__(cls, typename, bases, ns):
        assert bases[0] is _NamedTuple
        types = ns.get('__annotations__', {})
        default_names = []
        for field_name in types:
            if field_name in ns:
                default_names.append(field_name)
            elif default_names:
                raise TypeError(f"Non-default namedtuple field {field_name} "
                                f"cannot follow default field"
                                f"{'s' if len(default_names) > 1 else ''} "
                                f"{', '.join(default_names)}")
        nm_tpl = _make_nmtuple(typename, types.items(),
                               defaults=[ns[n] for n in default_names],
                               module=ns['__module__'])
        # update from user namespace without overriding special namedtuple attributes
        for key in ns:
            if key in _prohibited:
>               raise AttributeError("Cannot overwrite NamedTuple attribute " + key)
E               AttributeError: Cannot overwrite NamedTuple attribute __slots__

/Users/ryanc/opt/anaconda3/lib/python3.9/typing.py:1884: AttributeError
```
To resolve this, I deleted the lines passing `__slots__` to `type_kwargs`. Our unit test `test_instance_with_slots` still passes with this change. The deleted `__slots__` lines were written 4 years ago and are possibly no longer useful. If there is reason to believe removing it could cause a regression, we should at least add a unit test that properly tests the functionality provided by these lines.

I've run all unit tests locally with Python 3.6, 3.7, 3.8, 3.9, and 3.10 and verified non-regression. The new `NamedTuple` test fails on develop with Python 3.9 and 3.10 but passes on this branch. I'm happy to iterate here if there are changes needed.
