### PR TITLE
Update cloudpickle.py

### DIFF
--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -478,7 +478,7 @@ def _make_cell_set_template_code():
         co.co_cellvars,  # co_freevars is initialized with co_cellvars
         (),  # co_cellvars is made empty
     )
-    return _cell_set_template_code
+    return int(_cell_set_template_code)
 
 
 if sys.version_info[:2] < (3, 7):


### PR DESCRIPTION
returning int() converted cell_template_code as while installing pyspark (with python 3.7.0 + spark 2.4.1) we are facing below error:

C:\pyspark\spark-2.4.1-bin-hadoop2.7\python\pyspark\cloudpickle.py in <module>
    143 
    144 
--> 145 _cell_set_template_code = _make_cell_set_template_code()
    146 
    147 

C:\pyspark\spark-2.4.1-bin-hadoop2.7\python\pyspark\cloudpickle.py in _make_cell_set_template_code()
    124         )
    125     else:
--> 126         return types.CodeType(
    127             co.co_argcount,
    128             co.co_kwonlyargcount,

TypeError: an integer is required (got type bytes)