### PR TITLE
Handle removal of distutils from stdlib in Python 3.12

### DIFF
--- a/ci/install_coverage_subprocess_pth.py
+++ b/ci/install_coverage_subprocess_pth.py
@@ -3,13 +3,13 @@
 # http://coverage.readthedocs.io/en/latest/subprocess.html
 
 import os.path as op
-from distutils.sysconfig import get_python_lib
+from sysconfig import get_path
 
 FILE_CONTENT = u"""\
 import coverage; coverage.process_startup()
 """
 
-filename = op.join(get_python_lib(), 'coverage_subprocess.pth')
+filename = op.join(get_path('purelib'), 'coverage_subprocess.pth')
 with open(filename, 'wb') as f:
     f.write(FILE_CONTENT.encode('ascii'))
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,3 +15,5 @@ codecov
 coverage
 # Utility package used when running the cloudpickle test suite
 ./tests/cloudpickle_testpkg
+# Required for setup of the above utility package:
+setuptools; python_version >= '3.12'

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -740,13 +740,13 @@ class CloudPickleTest(unittest.TestCase):
     def test_module_importability(self):
         from cloudpickle.compat import pickle
         import os.path
-        import distutils
-        import distutils.ccompiler
+        import collections
+        import collections.abc
 
         assert _should_pickle_by_reference(pickle)
         assert _should_pickle_by_reference(os.path)  # fake (aliased) module
-        assert _should_pickle_by_reference(distutils)  # package
-        assert _should_pickle_by_reference(distutils.ccompiler)  # module in package
+        assert _should_pickle_by_reference(collections)  # package
+        assert _should_pickle_by_reference(collections.abc)  # module in package
 
         dynamic_module = types.ModuleType('dynamic_module')
         assert not _should_pickle_by_reference(dynamic_module)

--- a/tests/cloudpickle_testpkg/setup.py
+++ b/tests/cloudpickle_testpkg/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 
 dist = setup(


### PR DESCRIPTION
Fixes the following test failures, mentioned in https://github.com/cloudpipe/cloudpickle/issues/507:

```
FAILED tests/cloudpickle_test.py::CloudPickleTest::test_module_importability - ModuleNotFoundError: No module named 'distutils'
FAILED tests/cloudpickle_test.py::Protocol2CloudPickleTest::test_module_importability - ModuleNotFoundError: No module named 'distutils'
```