### PR TITLE
handle dataclass field type sentinels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
 2.3.0 (development)
 ===================
 
-TODO
-
+- Fix pickling of dataclasses and their instances.
+  ([issue #386](https://github.com/cloudpipe/cloudpickle/issues/386),
+   [PR #513](https://github.com/cloudpipe/cloudpickle/pull/513))
 
 2.2.1
 =====

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2794,7 +2794,6 @@ class CloudPickleTest(unittest.TestCase):
             "z": dataclasses._FIELD_CLASSVAR,
         }
 
-
         for f in found_fields:
             assert f._field_type is expected_ftypes[f.name]
 


### PR DESCRIPTION
Closes: #386

In short, the `dataclasses` module relies on the identity of certain sentinel values being preserved. To preserve their identity, this PR relies on a minimal set of internal dataclasses APIs to reduce those sentinels to their `_FIELD_BASE.name`. Then, when reconstituting them, the names key into a `_DATACLASSE_FIELD_TYPE_SENTINELS` mapping that contains the expected sentinel instances.

The implementation accesses the following private APIs:

- `dataclasses._FIELD_BASE`
- `dataclasses._FIELD`
- `dataclasses._FIELD_CLASSVAR`
- `dataclasses._FIELD_INITVAR`