### PR TITLE
Add support for Python 3.12 and drop EOL 3.6 and 3.7

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,9 +10,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python 3.11
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.11
     - name: Install flake8
@@ -32,8 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # TODO: add "3.12-dev" to the list
-        python_version: [3.7, 3.8, 3.9, "3.10", "3.11", "pypy-3.9"]
+        python_version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "pypy-3.9"]
         exclude:
           # Do not test all minor versions on all platforms, especially if they
           # are not the oldest/newest supported versions
@@ -56,11 +55,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python_version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python_version }}
+        allow-prereleases: true
     - name: Install project and dependencies
       shell: bash
       run: |
@@ -85,7 +85,7 @@ jobs:
         coverage combine --append
         coverage xml -i
     - name: Publish coverage results
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
@@ -101,9 +101,9 @@ jobs:
       matrix:
         python_version: ["3.10"]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python_version }}
     - name: Install project and dependencies
@@ -133,9 +133,9 @@ jobs:
       matrix:
         python_version: ["3.10"]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python_version }}
     - name: Install project and dependencies
@@ -161,9 +161,9 @@ jobs:
       matrix:
         python_version: ["3.10"]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python_version }}
     - name: Install downstream project and dependencies
@@ -186,9 +186,9 @@ jobs:
       matrix:
         python_version: ["3.10"]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python_version }}
     - name: Install project and dependencies

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,19 +32,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "pypy-3.9"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9"]
         exclude:
           # Do not test all minor versions on all platforms, especially if they
           # are not the oldest/newest supported versions
-          - os: windows-latest
-            python_version: 3.7
           - os: windows-latest
             python_version: 3.8
             # as of  4/02/2020, psutil won't build under PyPy + Windows
           - os: windows-latest
             python_version: "pypy-3.9"
-          - os: macos-latest
-            python_version: 3.7
           - os: macos-latest
             python_version: 3.8
           - os: macos-latest

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Running the tests
 
   or alternatively for a specific environment:
 
-      tox -e py37
+      tox -e py312
 
 
 - With `pytest` to only run the tests for your current version of

--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ Running the tests
       tox -e py37
 
 
-- With `py.test` to only run the tests for your current version of
+- With `pytest` to only run the tests for your current version of
   Python:
 
       pip install -r dev-requirements.txt
-      PYTHONPATH='.:tests' py.test
+      PYTHONPATH='.:tests' pytest
 
 History
 -------

--- a/ci/install_coverage_subprocess_pth.py
+++ b/ci/install_coverage_subprocess_pth.py
@@ -5,7 +5,7 @@
 import os.path as op
 from sysconfig import get_path
 
-FILE_CONTENT = u"""\
+FILE_CONTENT = """\
 import coverage; coverage.process_startup()
 """
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -62,7 +62,8 @@ from importlib._bootstrap import _find_spec
 
 try:  # pragma: no branch
     import typing_extensions as _typing_extensions
-    from typing_extensions import Literal, Final
+    from typing_extensions import Literal
+    from typing import Final
 except ImportError:
     _typing_extensions = Literal = Final = None
 

--- a/cloudpickle/cloudpickle_fast.py
+++ b/cloudpickle/cloudpickle_fast.py
@@ -355,7 +355,7 @@ def _file_reduce(obj):
         obj.seek(0)
         contents = obj.read()
         obj.seek(curloc)
-    except IOError as e:
+    except OSError as e:
         raise pickle.PicklingError(
             "Cannot pickle file %s as it cannot be read" % name
         ) from e

--- a/cloudpickle/compat.py
+++ b/cloudpickle/compat.py
@@ -1,18 +1,5 @@
-import sys
+import pickle  # noqa: F401
 
-
-if sys.version_info < (3, 8):
-    try:
-        import pickle5 as pickle  # noqa: F401
-        from pickle5 import Pickler  # noqa: F401
-    except ImportError:
-        import pickle  # noqa: F401
-
-        # Use the Python pickler for old CPython versions
-        from pickle import _Pickler as Pickler  # noqa: F401
-else:
-    import pickle  # noqa: F401
-
-    # Pickler will the C implementation in CPython and the Python
-    # implementation in PyPy
-    from pickle import Pickler  # noqa: F401
+# Pickler will the C implementation in CPython and the Python
+# implementation in PyPy
+from pickle import Pickler  # noqa: F401

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-# Dependencies for running the tests with py.test
+# Dependencies for running the tests with pytest
 flake8
 pytest
 pytest-cov

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,8 +3,6 @@ flake8
 pytest
 pytest-cov
 psutil
-# To test on older Python versions
-pickle5 >=0.0.11 ; python_version == '3.7' and python_implementation == 'CPython'
 # To be able to test tornado coroutines
 tornado
 # To be able to test numpy specific things

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,6 @@ setup(
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: MacOS :: MacOS X',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -53,5 +51,5 @@ setup(
         'Topic :: System :: Distributed Computing',
     ],
     test_suite='tests',
-    python_requires='>=3.6',
+    python_requires='>=3.8',
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def find_version():
     raise RuntimeError("Unable to find version string.")
 
 
-dist = setup(
+setup(
     name='cloudpickle',
     version=find_version(),
     description='Extended pickling support for Python objects',
@@ -43,6 +43,9 @@ dist = setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import os
 import re
 
@@ -12,7 +11,7 @@ except ImportError:
 # Function to parse __version__ in `cloudpickle/__init__.py`
 def find_version():
     here = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(here, 'cloudpickle', '__init__.py'), 'r') as fp:
+    with open(os.path.join(here, 'cloudpickle', '__init__.py')) as fp:
         version_file = fp.read()
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
                               version_file, re.M)

--- a/tests/cloudpickle_file_test.py
+++ b/tests/cloudpickle_file_test.py
@@ -25,7 +25,7 @@ class CloudPickleFileTests(unittest.TestCase):
     def test_empty_file(self):
         # Empty file
         open(self.tmpfilepath, 'w').close()
-        with open(self.tmpfilepath, 'r') as f:
+        with open(self.tmpfilepath) as f:
             self.assertEqual('', pickle.loads(cloudpickle.dumps(f)).read())
         os.remove(self.tmpfilepath)
 
@@ -43,7 +43,7 @@ class CloudPickleFileTests(unittest.TestCase):
         with open(self.tmpfilepath, 'w') as f:
             f.write(self.teststring)
         # Open for reading
-        with open(self.tmpfilepath, 'r') as f:
+        with open(self.tmpfilepath) as f:
             new_f = pickle.loads(cloudpickle.dumps(f))
             self.assertEqual(self.teststring, new_f.read())
         os.remove(self.tmpfilepath)

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -475,8 +475,7 @@ class CloudPickleTest(unittest.TestCase):
     def test_generator(self):
 
         def some_generator(cnt):
-            for i in range(cnt):
-                yield i
+            yield from range(cnt)
 
         gen2 = pickle_depickle(some_generator, protocol=self.protocol)
 

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -132,7 +132,7 @@ class CloudPickleTest(unittest.TestCase):
 
     @pytest.mark.skipif(
             platform.python_implementation() != "CPython" or
-            (sys.version_info >= (3, 8, 0) and sys.version_info < (3, 8, 2)),
+            sys.version_info < (3, 8, 2),
             reason="Underlying bug fixed upstream starting Python 3.8.2")
     def test_reducer_override_reference_cycle(self):
         # Early versions of Python 3.8 introduced a reference cycle between a
@@ -766,8 +766,6 @@ class CloudPickleTest(unittest.TestCase):
         # Check for similar behavior for a module that cannot be imported by
         # attribute lookup.
         from _cloudpickle_testpkg.mod import dynamic_submodule_two as m2
-        # Note: import _cloudpickle_testpkg.mod.dynamic_submodule_two as m2
-        # works only for Python 3.7+
         assert _should_pickle_by_reference(m2)
         assert pickle_depickle(m2, protocol=self.protocol) is m2
 
@@ -2744,10 +2742,6 @@ class CloudPickleTest(unittest.TestCase):
             if "_cloudpickle_testpkg" in list_registry_pickle_by_value():
                 unregister_pickle_by_value(_cloudpickle_testpkg)
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 7),
-        reason="Determinism can only be guaranteed for Python 3.7+"
-    )
     def test_deterministic_pickle_bytes_for_function(self):
         # Ensure that functions with references to several global names are
         # pickled to fixed bytes that do not depend on the PYTHONHASHSEED of

--- a/tests/cloudpickle_testpkg/setup.py
+++ b/tests/cloudpickle_testpkg/setup.py
@@ -4,7 +4,7 @@ except ImportError:
     from distutils.core import setup
 
 
-dist = setup(
+setup(
     name='cloudpickle_testpkg',
     version='0.0.0',
     description='Package used only for cloudpickle testing purposes',
@@ -12,5 +12,5 @@ dist = setup(
     author_email='cloudpipe@googlegroups.com',
     license='BSD 3-Clause License',
     packages=['_cloudpickle_testpkg'],
-    python_requires='>=3.5',
+    python_requires='>=3.8',
 )

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -19,9 +19,7 @@ from .generate_old_pickles import PICKLE_DIRECTORY
 
 def load_obj(filename, check_deprecation_warning='auto'):
     if check_deprecation_warning == 'auto':
-        # pickles files generated with cloudpickle_fast.py on old versions of
-        # coudpickle with Python < 3.8 use non-deprecated reconstructors.
-        check_deprecation_warning = (sys.version_info < (3, 8))
+        check_deprecation_warning = False
     pickle_filepath = PICKLE_DIRECTORY / filename
     if not pickle_filepath.exists():
         pytest.skip(f"Could not find {str(pickle_filepath)}")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36, 37, 38, 39, 310, 311, 312, py3}
+envlist = py{38, 39, 310, 311, 312, py3}
 
 [testenv]
 deps = -rdev-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, py39, py310, py311, pypy3
+envlist = py{36, 37, 38, 39, 310, 311, 312, py3}
 
 [testenv]
 deps = -rdev-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps = -rdev-requirements.txt
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/tests
 commands =
-     py.test {posargs:-lv --maxfail=5}
+     pytest {posargs:-lv --maxfail=5}
 
 [pytest]
 addopts = -s


### PR DESCRIPTION
The [second Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105/5?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

See also https://dev.to/hugovk/help-test-python-312-beta-1508/

---

Python 3.6 and 3.7 are EOL and no longer receiving security updates (or any updates) from the core Python team.
<img width="769" alt="image" src="https://github.com/cloudpipe/cloudpickle/assets/1324225/2be6622a-fde0-4195-a963-caf14e854236">


https://devguide.python.org/versions/
