### PR TITLE
Fix `distributed` downstream tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,7 +2,7 @@ name: Automated Tests
 
 on:
   push:
-    # branches: master
+    branches: master
   pull_request:
     branches: master
 
@@ -92,7 +92,7 @@ jobs:
 
   distributed-downstream-build:
     runs-on: ubuntu-latest
-    # if: "contains(github.event.pull_request.labels.*.name, 'ci distributed') || contains(github.event.pull_request.labels.*.name, 'ci downstream')"
+    if: "contains(github.event.pull_request.labels.*.name, 'ci distributed') || contains(github.event.pull_request.labels.*.name, 'ci downstream')"
     env:
       PROJECT: distributed
       TEST_REQUIREMENTS: cryptography pytest pytest-asyncio<0.14.0 pytest-timeout pytest-rerunfailures pytest-cov numpy pandas mock bokeh fsspec>=0.3.3 aiohttp pyarrow git+https://github.com/dask/dask

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,7 +2,7 @@ name: Automated Tests
 
 on:
   push:
-    branches: master
+    # branches: master
   pull_request:
     branches: master
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -92,10 +92,10 @@ jobs:
 
   distributed-downstream-build:
     runs-on: ubuntu-latest
-    if: "contains(github.event.pull_request.labels.*.name, 'ci distributed') || contains(github.event.pull_request.labels.*.name, 'ci downstream')"
+    # if: "contains(github.event.pull_request.labels.*.name, 'ci distributed') || contains(github.event.pull_request.labels.*.name, 'ci downstream')"
     env:
       PROJECT: distributed
-      TEST_REQUIREMENTS: cryptography pytest pytest-asyncio<0.14.0 pytest-timeout pytest-rerunfailures numpy pandas mock bokeh fsspec>=0.3.3 aiohttp pyarrow git+https://github.com/dask/dask
+      TEST_REQUIREMENTS: cryptography pytest pytest-asyncio<0.14.0 pytest-timeout pytest-rerunfailures pytest-cov numpy pandas mock bokeh fsspec>=0.3.3 aiohttp pyarrow git+https://github.com/dask/dask
       PROJECT_URL: https://github.com/dask/distributed.git
     strategy:
       matrix:


### PR DESCRIPTION
Adding `pytest-cov` as a testing dependency unblocks the `distributed` CI tests. Now let's see if they actually pass...