### PR TITLE
Official py 3.13 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Software Development :: Libraries :: Python Modules',
@@ -31,7 +32,7 @@ classifiers = [
 
 [tool.black]
 line-length = 88
-target_version = ['py38', 'py39', 'py310', 'py311', 'py312']
+target_version = ['py38', 'py39', 'py310', 'py311', 'py312', 'py313']
 preview = true
 
 [tool.ruff]


### PR DESCRIPTION
Forgot to do it before the 3.1.0 release. Should not impact most users though, but better try to keep the package metadata in sync for the next one.