### PR TITLE
MAINT fix placeholder with correct package name in test.pypi.org publishing config

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -104,7 +104,7 @@ jobs:
 
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/<package-name>
+      url: https://test.pypi.org/p/cloudpickle
 
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing


### PR DESCRIPTION
This will hopefully fix https://github.com/cloudpipe/cloudpickle/pull/548#issuecomment-2590237355.