### PR TITLE
MAINT prepare bugfix release 3.1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 In development
 ==============
 
+3.1.1
+=====
+
 - Various fixes to support for Python 3.14 ([PR #545](
   https://github.com/cloudpipe/cloudpickle/pull/545)).
 

--- a/cloudpickle/__init__.py
+++ b/cloudpickle/__init__.py
@@ -3,7 +3,7 @@ from .cloudpickle import *  # noqa
 
 __doc__ = cloudpickle.__doc__
 
-__version__ = "3.2.0.dev0"
+__version__ = "3.1.1"
 
 __all__ = [  # noqa
     "__version__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
Mostly to add anticipated support for alpha versions of Python 3.14.

And also test the new trusted publishers-based release automation.