### PR TITLE
MAINT Set __version__ back to 3.2.0.dev0

### DIFF
--- a/cloudpickle/__init__.py
+++ b/cloudpickle/__init__.py
@@ -3,7 +3,7 @@ from .cloudpickle import *  # noqa
 
 __doc__ = cloudpickle.__doc__
 
-__version__ = "3.1.1"
+__version__ = "3.2.0.dev0"
 
 __all__ = [  # noqa
     "__version__",


### PR DESCRIPTION
Release 3.1.1 was successful and now includes provenance tracking metadata and externally hosted signatures :)

https://pypi.org/project/cloudpickle/3.1.1/#cloudpickle-3.1.1-py3-none-any.whl