### PR TITLE
Fix #567: Fix test_locally_defined_class_with_type_hints()

### DIFF
--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -2658,7 +2658,9 @@ class CloudPickleTest(unittest.TestCase):
                 MyClass.__annotations__ = {"attribute": type_}
 
                 def check_annotations(obj, expected_type, expected_type_str):
-                    assert obj.__annotations__["attribute"] == expected_type
+                    # On Python 3.14, it's no longer possible to access class
+                    # annotations from an instance, so use type().
+                    assert type(obj).__annotations__["attribute"] == expected_type
                     assert obj.method.__annotations__["arg"] == expected_type
                     assert obj.method.__annotations__["return"] == expected_type
                     return "ok"


### PR DESCRIPTION
Update the test for Python 3.14 beta 1. What's New in Python 3.14 says:

"In previous releases, it was sometimes possible to access class annotations from an instance of an annotated class. This behavior was undocumented and accidental, and will no longer work in Python 3.14."

https://docs.python.org/3.14/whatsnew/3.14.html#related-changes